### PR TITLE
Rename the package to eslint-plugin-colocate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for agents working on this repository. Consumer-facing usage lives in `
 
 ## What this is
 
-ESLint 9+ plugin (`file-ownership-lint/ownership`) that walks a source tree, builds an import graph, and reports files whose **location** does not match **who depends on them**. ESM only, Node 20+, TypeScript with `module: NodeNext`. Tests import `src/` directly; `npm run build` emits `dist/` for the published package.
+ESLint 9+ plugin (`colocate/ownership`) that walks a source tree, builds an import graph, and reports files whose **location** does not match **who depends on them**. ESM only, Node 20+, TypeScript with `module: NodeNext`. Tests import `src/` directly; `npm run build` emits `dist/` for the published package.
 
 Peer: `eslint >= 9`. Developed against ESLint 10. TypeScript is both a runtime dependency (compiler API for parse/resolve) and a devDependency.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# file-ownership-lint
+# eslint-plugin-colocate
 
 ESLint (v9+) plugin that flags source files sitting in the wrong place, given who imports them.
 
@@ -13,15 +13,15 @@ npm install -D gosukiwi/file-ownership-lint
 ## Usage
 
 ```js
-import fileOwnershipLint from "file-ownership-lint";
+import colocate from "eslint-plugin-colocate";
 
 export default [
   {
     plugins: {
-      "file-ownership-lint": fileOwnershipLint,
+      colocate,
     },
     rules: {
-      "file-ownership-lint/ownership": [
+      "colocate/ownership": [
         "error",
         {
           root: "src",

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 import ownership from "./rules/ownership.js";
 export default {
     meta: {
-        name: "file-ownership-lint",
+        name: "eslint-plugin-colocate",
         version: "0.0.0",
     },
     rules: {

--- a/dist/lib/graph.js
+++ b/dist/lib/graph.js
@@ -395,7 +395,7 @@ function aliasCandidates(specifier, options) {
 }
 export function resolveSpecifier(specifier, fromDir, settings) {
     const options = settings?.options ?? RESOLUTION_OVERRIDES;
-    const { resolvedModule } = ts.resolveModuleName(specifier, path.join(fromDir, "__file-ownership-lint__.ts"), options, ts.sys, settings?.cache);
+    const { resolvedModule } = ts.resolveModuleName(specifier, path.join(fromDir, "__colocate__.ts"), options, ts.sys, settings?.cache);
     if (resolvedModule !== undefined && isSourceFile(resolvedModule.resolvedFileName)) {
         const resolved = safeRealpath(resolvedModule.resolvedFileName);
         if (resolved !== undefined) {

--- a/dist/rules/ownership.js
+++ b/dist/rules/ownership.js
@@ -155,23 +155,25 @@ const rule = {
                 const graph = getGraph(rootDir, ignore, realFilename);
                 const layerDirs = resolveLayerDirectories(graph, cwd, layers, realRootDir);
                 const ownershipContext = { graph, rootDir: realRootDir, layerDirs };
+                // Report on the first statement so eslint-disable comments still apply under ESLint 10.
+                const reportNode = node.body[0] ?? node;
                 if (realDir !== realRootDir &&
                     isSingletonWrapperDirectory(realDir, realFilename, realRootDir, ignore)) {
                     context.report({
-                        node,
+                        node: reportNode,
                         messageId: "singletonFolder",
                     });
                 }
                 if (isPrivateOutsideOwner(realFilename, ownershipContext)) {
                     context.report({
-                        node,
+                        node: reportNode,
                         messageId: "privateOutsideOwner",
                     });
                 }
                 const sharedIssue = getSharedColocationIssue(realFilename, ownershipContext);
                 if (sharedIssue !== undefined) {
                     context.report({
-                        node,
+                        node: reportNode,
                         messageId: sharedIssue,
                     });
                 }
@@ -222,7 +224,7 @@ const rule = {
                     return;
                 }
                 context.report({
-                    node,
+                    node: reportNode,
                     messageId: "mismatchedEntry",
                 });
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "file-ownership-lint",
+  "name": "eslint-plugin-colocate",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "file-ownership-lint",
+      "name": "eslint-plugin-colocate",
       "version": "0.0.0",
       "dependencies": {
         "minimatch": "^10",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "file-ownership-lint",
+  "name": "eslint-plugin-colocate",
   "version": "0.0.0",
   "type": "module",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import ownership from "./rules/ownership.js";
 
 export default {
   meta: {
-    name: "file-ownership-lint",
+    name: "eslint-plugin-colocate",
     version: "0.0.0",
   },
   rules: {

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -529,7 +529,7 @@ export function resolveSpecifier(
   const options = settings?.options ?? RESOLUTION_OVERRIDES;
   const { resolvedModule } = ts.resolveModuleName(
     specifier,
-    path.join(fromDir, "__file-ownership-lint__.ts"),
+    path.join(fromDir, "__colocate__.ts"),
     options,
     ts.sys,
     settings?.cache,

--- a/tests/fixtures/eslint-disable-ownership-js/src/Foo/Foo.js
+++ b/tests/fixtures/eslint-disable-ownership-js/src/Foo/Foo.js
@@ -1,3 +1,3 @@
 // leading trivia; Program reports start at offset 0 in ESLint 10
-/* eslint-disable file-ownership-lint/ownership */
+/* eslint-disable colocate/ownership */
 export const foo = 1;

--- a/tests/fixtures/eslint-disable-ownership/src/Foo/Foo.ts
+++ b/tests/fixtures/eslint-disable-ownership/src/Foo/Foo.ts
@@ -1,3 +1,3 @@
 // leading trivia; Program reports start at offset 0 in ESLint 10
-/* eslint-disable file-ownership-lint/ownership */
+/* eslint-disable colocate/ownership */
 export const foo = 1;

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -86,7 +86,7 @@ describe("getGraph", () => {
 
     const outsideFile = path.join(
       os.tmpdir(),
-      `file-ownership-lint-outside-${process.pid}.ts`,
+      `colocate-outside-${process.pid}.ts`,
     );
     try {
       fs.writeFileSync(outsideFile, "export const x = 1;\n");

--- a/tests/helpers/lint-fixture.ts
+++ b/tests/helpers/lint-fixture.ts
@@ -35,10 +35,10 @@ export function makeESLint(
       {
         files: ["**/*.{js,jsx,ts,tsx,mts,cts,mjs,cjs}"],
         plugins: {
-          "file-ownership-lint": plugin,
+          colocate: plugin,
         },
         rules: {
-          "file-ownership-lint/ownership": ["error", ruleOptions ?? {}],
+          "colocate/ownership": ["error", ruleOptions ?? {}],
         },
         languageOptions,
       },
@@ -61,7 +61,7 @@ export function collectMessages(
         );
         continue;
       }
-      if (message.ruleId === "file-ownership-lint/ownership" && message.messageId) {
+      if (message.ruleId === "colocate/ownership" && message.messageId) {
         messages.push({
           file: path.relative(cwd, result.filePath),
           messageId: message.messageId,

--- a/tests/ownership.test.ts
+++ b/tests/ownership.test.ts
@@ -555,10 +555,10 @@ describe("ownership rule", () => {
         {
           files: ["**/*.{js,jsx,ts,tsx,mts,cts,mjs,cjs}"],
           plugins: {
-            "file-ownership-lint": plugin,
+            colocate: plugin,
           },
           rules: {
-            "file-ownership-lint/ownership": ["error", {}],
+            "colocate/ownership": ["error", {}],
           },
           languageOptions: {
             parser: tsParser,
@@ -577,7 +577,7 @@ describe("ownership rule", () => {
     for (const result of results) {
       for (const message of result.messages) {
         if (
-          message.ruleId === "file-ownership-lint/ownership" &&
+          message.ruleId === "colocate/ownership" &&
           message.messageId
         ) {
           messages.push({

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -3,7 +3,7 @@ import plugin from "../src/index.js";
 
 describe("plugin", () => {
   it("exports rules.ownership and meta.name", () => {
-    expect(plugin.meta.name).toBe("file-ownership-lint");
+    expect(plugin.meta.name).toBe("eslint-plugin-colocate");
     expect(plugin.rules.ownership).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- Rename the npm package and plugin `meta.name` to `eslint-plugin-colocate`.
- Configs and disable comments now use `colocate/ownership` instead of `file-ownership-lint/ownership`.
- GitHub install and docs URLs still point at this repo so they keep working until the GitHub repo itself is renamed.

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [ ] After merge, rename the GitHub repo if you want install/docs URLs to match the new package name.


Made with [Cursor](https://cursor.com)