### PR TITLE
Point install and docs URLs at the renamed GitHub repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ scripts/check-placement.ts  opt-in satisfiability sweep
 
 `plugin.meta.version` is hardcoded in `src/index.ts`. `tests/plugin-meta.test.ts` asserts it matches `package.json` — bump both.
 
-Rule docs URL is `https://github.com/gosukiwi/file-ownership-lint#what-it-reports`. Keep a heading that GitHub slugifies to `#what-it-reports` in the README.
+Rule docs URL is `https://github.com/gosukiwi/eslint-plugin-colocate#what-it-reports`. Keep a heading that GitHub slugifies to `#what-it-reports` in the README.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A file used by one module belongs inside that module's folder. A file used by se
 ## Install
 
 ```bash
-npm install -D gosukiwi/file-ownership-lint
+npm install -D gosukiwi/eslint-plugin-colocate
 ```
 
 ## Usage

--- a/dist/rules/ownership.js
+++ b/dist/rules/ownership.js
@@ -103,7 +103,7 @@ const rule = {
         type: "problem",
         docs: {
             description: "Enforce dependency-ownership file layout",
-            url: "https://github.com/gosukiwi/file-ownership-lint#what-it-reports",
+            url: "https://github.com/gosukiwi/eslint-plugin-colocate#what-it-reports",
         },
         schema: [
             {

--- a/src/rules/ownership.ts
+++ b/src/rules/ownership.ts
@@ -153,7 +153,7 @@ const rule: Rule.RuleModule = {
     type: "problem",
     docs: {
       description: "Enforce dependency-ownership file layout",
-      url: "https://github.com/gosukiwi/file-ownership-lint#what-it-reports",
+      url: "https://github.com/gosukiwi/eslint-plugin-colocate#what-it-reports",
     },
     schema: [
       {


### PR DESCRIPTION
## Summary
- Update the README install path, rule docs URL, and AGENTS.md to `gosukiwi/eslint-plugin-colocate` now that the GitHub repo has been renamed.

## Test plan
- [x] `npm test`
- [ ] Confirm `npm install -D gosukiwi/eslint-plugin-colocate` and the rule docs link resolve.


Made with [Cursor](https://cursor.com)