### PR TITLE
Remove code comments

### DIFF
--- a/dist/lib/derived.d.ts
+++ b/dist/lib/derived.d.ts
@@ -1,17 +1,4 @@
 import type { Graph } from "./graph.js";
-/**
- * An index derived from a graph, memoised for exactly as long as that graph
- * lives.
- *
- * Six hand-rolled `WeakMap<Graph, X>` tables repeating one get/undefined/build/
- * set dance had accumulated across three modules (resolution settings, the
- * member set, the folded-path index, gates, shells, layer directories). The
- * lifetime rule all six rely on is worth stating once: a graph is immutable
- * (see `Graph`), so an index built from one stays true for as long as that
- * object exists, and a changed tree produces a *new* graph object whose indexes
- * are therefore empty. Nothing needs invalidating, and nothing here keeps a
- * graph alive - the table is weak.
- */
 export declare function derivedFromGraph<T, A extends unknown[] = []>(build: (graph: Graph, ...args: A) => T): ((graph: Graph, ...args: A) => T) & {
     prime: (graph: Graph, value: T) => void;
 };

--- a/dist/lib/derived.js
+++ b/dist/lib/derived.js
@@ -1,23 +1,5 @@
-/**
- * An index derived from a graph, memoised for exactly as long as that graph
- * lives.
- *
- * Six hand-rolled `WeakMap<Graph, X>` tables repeating one get/undefined/build/
- * set dance had accumulated across three modules (resolution settings, the
- * member set, the folded-path index, gates, shells, layer directories). The
- * lifetime rule all six rely on is worth stating once: a graph is immutable
- * (see `Graph`), so an index built from one stays true for as long as that
- * object exists, and a changed tree produces a *new* graph object whose indexes
- * are therefore empty. Nothing needs invalidating, and nothing here keeps a
- * graph alive - the table is weak.
- */
 export function derivedFromGraph(build) {
     const table = new WeakMap();
-    // Keyed on the graph alone, so extra arguments feed the first build only.
-    // That is honest for a build input the graph itself determines - a graph
-    // object belongs to exactly one (root, ignore) pair - and wrong for anything
-    // that can genuinely differ per call (see resolveLayerDirectories, which keys
-    // those inside its own value).
     const get = (graph, ...args) => {
         let value = table.get(graph);
         if (value === undefined) {
@@ -26,8 +8,6 @@ export function derivedFromGraph(build) {
         }
         return value;
     };
-    // For a caller that already holds the index and would otherwise pay to have
-    // it rebuilt on first use.
     get.prime = (graph, value) => {
         table.set(graph, value);
     };

--- a/dist/lib/findings.d.ts
+++ b/dist/lib/findings.d.ts
@@ -1,27 +1,3 @@
 import type { Subject } from "./subject.js";
-/**
- * Everything `colocate/ownership` can say about a file.
- *
- * The two decisions below - is this directory a singleton wrapper, is this index
- * a stand-in for one sibling - lived in the rule until they were moved here, for
- * the reason `gates.ts` exists: a rule file should read as an adapter between
- * ESLint and a model, and the model should be answerable (and testable) without
- * one. `owners.ts` holds the predicates that answer "who owns this file" from the
- * import graph; this module holds what the rule *reports* and in which order,
- * plus the two questions no other caller asks - one of which is a directory walk
- * that never touches the graph at all.
- */
 export type OwnershipFinding = "singletonFolder" | "privateOutsideOwner" | "sharedTooHigh" | "sharedInsideOwner" | "mismatchedEntry";
-/**
- * Every finding for this file, **in report order**.
- *
- * The order is part of the contract, not an accident of how this reads: the
- * fixture assertions sort, but `check:placement` prints a per-placement matrix of
- * raw sequences and the differential compares raw output, so reordering these
- * four pushes would show up as a diff with no behaviour behind it.
- *
- * Nothing here short-circuits, again deliberately: a file can be a singleton
- * wrapper *and* misplaced relative to its owner, and each report names a
- * different edit.
- */
 export declare function ownershipFindings(subject: Subject, cwd: string, layers: string[]): OwnershipFinding[];

--- a/dist/lib/findings.js
+++ b/dist/lib/findings.js
@@ -13,13 +13,9 @@ function countSourceFilesRecursive(dir, rootDir, ignore) {
     for (const entry of safeReaddir(dir)) {
         const fullPath = path.join(dir, entry.name);
         const relPath = path.relative(rootDir, fullPath);
-        // Files excluded from the graph must not count here either, or an ignored
-        // generated file keeps a wrapper directory looking populated.
         if (matchesIgnore(relPath, ignore)) {
             continue;
         }
-        // Symlinks read as neither file nor directory, so a linked subdirectory of
-        // sources used to leave the parent looking like a single-file wrapper.
         const stat = entry.isSymbolicLink() ? safeStat(fullPath) : undefined;
         const isDirectory = entry.isSymbolicLink()
             ? (stat?.isDirectory() ?? false)
@@ -43,26 +39,16 @@ function countSourceFilesRecursive(dir, rootDir, ignore) {
     }
     return sourceCount;
 }
-// Only beside the file: a stylesheet several directories down is not a
-// companion, and treating it as one silently exempted the wrapper.
 function hasCompanionStylesheet(dir) {
     return safeReaddir(dir).some((entry) => {
         if (!isStylesheet(entry.name)) {
             return false;
         }
-        // readdir reports a symlink as neither file nor directory.
         return entry.isSymbolicLink()
             ? (safeStat(path.join(dir, entry.name))?.isFile() ?? false)
             : entry.isFile();
     });
 }
-/**
- * Whether `dir` holds nothing but this one file, which could therefore live in
- * the parent directory instead.
- *
- * Answered from disk rather than from the graph on purpose: the question is what
- * the directory contains, and a source file nobody imports is still content.
- */
 function isSingletonWrapperDirectory(dir, filename, rootDir, ignore) {
     if (countSourceFilesRecursive(dir, rootDir, ignore) !== 1 ||
         hasCompanionStylesheet(dir)) {
@@ -72,14 +58,6 @@ function isSingletonWrapperDirectory(dir, filename, rootDir, ignore) {
     const fileBasename = path.basename(filename, path.extname(filename));
     return fileBasename === dirName || fileBasename === "index";
 }
-/**
- * Whether outside code enters this directory through a barrel that only stands
- * in for one differently-named sibling, so the sibling should be imported (or
- * renamed) directly.
- *
- * Precondition: `indexFile` is an index file (see `ownershipFindings`, which is
- * where that is decided, and why it is decided of the linted path).
- */
 function isMismatchedEntry(indexFile, ctx) {
     const dir = path.dirname(indexFile);
     if (dir === ctx.rootDir) {
@@ -105,34 +83,15 @@ function isMismatchedEntry(indexFile, ctx) {
         return false;
     }
     const { local, total } = collectReExports(indexFile, dir, ctx.graph);
-    // An index that also re-exports modules from elsewhere is an aggregator,
-    // not a stand-in for one sibling: the message would name a "named entry
-    // file" that does not exist and dropping the barrel would lose the rest.
     if (local.length !== 1 || total !== 1) {
         return false;
     }
-    // Only modules the graph knows about, so the message cannot point at a
-    // file the user has excluded.
     if (!graphHasFile(ctx.graph, local[0])) {
         return false;
     }
-    // Re-exporting the directory's own named entry keeps the folder a real
-    // owner; the barrel only makes `./Foo` resolve to `Foo/Foo.ts`.
     const target = local[0];
     return path.basename(target, path.extname(target)) !== path.basename(dir);
 }
-/**
- * Every finding for this file, **in report order**.
- *
- * The order is part of the contract, not an accident of how this reads: the
- * fixture assertions sort, but `check:placement` prints a per-placement matrix of
- * raw sequences and the differential compares raw output, so reordering these
- * four pushes would show up as a diff with no behaviour behind it.
- *
- * Nothing here short-circuits, again deliberately: a file can be a singleton
- * wrapper *and* misplaced relative to its owner, and each report names a
- * different edit.
- */
 export function ownershipFindings(subject, cwd, layers) {
     const { realRootDir: rootDir, file, ignore } = subject;
     const dir = path.dirname(file);
@@ -154,9 +113,6 @@ export function ownershipFindings(subject, cwd, layers) {
     if (sharedIssue !== undefined) {
         findings.push(sharedIssue);
     }
-    // Asked of `lintedPath` rather than of the realpathed `file`, which is what
-    // this decision has always keyed on - see `Subject.lintedPath`. Everything
-    // below it is about the real directory.
     const lintedBase = path.basename(subject.lintedPath, path.extname(subject.lintedPath));
     if (lintedBase === "index" && isMismatchedEntry(file, ctx)) {
         findings.push("mismatchedEntry");

--- a/dist/lib/fs-safe.js
+++ b/dist/lib/fs-safe.js
@@ -1,7 +1,4 @@
 import fs from "node:fs";
-// The rule runs inside ESLint's process: an uncaught fs error here aborts the
-// user's entire lint run. Every filesystem read goes through these helpers, and
-// a missing or unreadable path always degrades to "skip" rather than throwing.
 export function safeRealpath(filePath) {
     try {
         return fs.realpathSync(filePath);

--- a/dist/lib/gates.d.ts
+++ b/dist/lib/gates.d.ts
@@ -1,20 +1,5 @@
 import type { Graph } from "./graph.js";
-/**
- * Structural on purpose. The ownership model only treats an `index` as an entry
- * when code outside the directory imports through it, because a convenience
- * barrel over loose helpers must not redraw ownership boundaries. Access is the
- * other question: a door is a door the moment it exists, or adding one would
- * gate nothing until every consumer had already migrated to it.
- */
 export declare function isEntryFile(filePath: string): boolean;
-/**
- * Every gated directory mapped to the entry that names it. `index` wins over a
- * directory-named sibling regardless of which the walk sees first: it is the
- * door that makes the bare directory specifier resolve, so it is the shorter
- * fix to suggest. Between two `index` spellings (a migration in progress) the
- * first one in the sorted `graph.files` wins - a real ordering artefact, not a
- * meaningful choice between them.
- */
 export declare const getGates: ((graph: Graph) => ReadonlyMap<string, string>) & {
     prime: (graph: Graph, value: ReadonlyMap<string, string>) => void;
 };
@@ -22,23 +7,4 @@ export interface CrossedGate {
     dir: string;
     entry: string;
 }
-/**
- * The innermost gate containing `target` but not `importer`, or undefined when
- * no boundary separates them.
- *
- * Walking up from the target finds the innermost one directly: a deeper gate
- * always nests inside a shallower one, so an importer inside the deeper gate is
- * inside the shallower one too. The first directory that both gates the target
- * and excludes the importer is therefore the innermost such gate.
- *
- * Precondition: `target`, `importer`, and `rootDir` must already be in the
- * graph's own casing. `rootDir` comes from config and is compared only against
- * itself, so it needs no help. Neither `target` nor `importer` is canonical on
- * arrival on a case-insensitive disk: `resolveSpecifier` hands back whatever
- * casing the specifier text used, and `fs.realpathSync` does not fold case, so
- * the linted path ESLint reports carries whatever casing invoked it. Pass both
- * through `canonicalGraphPath` first - a non-canonical `importer` makes
- * `isInsideDir` miss, which reports a file for reaching into the very
- * directory it lives in and names a fix that would import its own door.
- */
 export declare function findCrossedGate(target: string, importer: string, graph: Graph, rootDir: string): CrossedGate | undefined;

--- a/dist/lib/gates.js
+++ b/dist/lib/gates.js
@@ -1,25 +1,10 @@
 import path from "node:path";
 import { derivedFromGraph } from "./derived.js";
 import { isInsideDir } from "./paths.js";
-/**
- * Structural on purpose. The ownership model only treats an `index` as an entry
- * when code outside the directory imports through it, because a convenience
- * barrel over loose helpers must not redraw ownership boundaries. Access is the
- * other question: a door is a door the moment it exists, or adding one would
- * gate nothing until every consumer had already migrated to it.
- */
 export function isEntryFile(filePath) {
     const base = path.basename(filePath, path.extname(filePath));
     return base === "index" || base === path.basename(path.dirname(filePath));
 }
-/**
- * Every gated directory mapped to the entry that names it. `index` wins over a
- * directory-named sibling regardless of which the walk sees first: it is the
- * door that makes the bare directory specifier resolve, so it is the shorter
- * fix to suggest. Between two `index` spellings (a migration in progress) the
- * first one in the sorted `graph.files` wins - a real ordering artefact, not a
- * meaningful choice between them.
- */
 export const getGates = derivedFromGraph((graph) => {
     const gates = new Map();
     for (const file of graph.files) {
@@ -37,28 +22,7 @@ export const getGates = derivedFromGraph((graph) => {
     }
     return gates;
 });
-/**
- * The innermost gate containing `target` but not `importer`, or undefined when
- * no boundary separates them.
- *
- * Walking up from the target finds the innermost one directly: a deeper gate
- * always nests inside a shallower one, so an importer inside the deeper gate is
- * inside the shallower one too. The first directory that both gates the target
- * and excludes the importer is therefore the innermost such gate.
- *
- * Precondition: `target`, `importer`, and `rootDir` must already be in the
- * graph's own casing. `rootDir` comes from config and is compared only against
- * itself, so it needs no help. Neither `target` nor `importer` is canonical on
- * arrival on a case-insensitive disk: `resolveSpecifier` hands back whatever
- * casing the specifier text used, and `fs.realpathSync` does not fold case, so
- * the linted path ESLint reports carries whatever casing invoked it. Pass both
- * through `canonicalGraphPath` first - a non-canonical `importer` makes
- * `isInsideDir` miss, which reports a file for reaching into the very
- * directory it lives in and names a fix that would import its own door.
- */
 export function findCrossedGate(target, importer, graph, rootDir) {
-    // Checked against the file itself, not against the gate map: a directory with
-    // both doors maps only to its index, and `Dir/Dir.ts` is still a legal target.
     if (isEntryFile(target)) {
         return undefined;
     }

--- a/dist/lib/graph-cache.d.ts
+++ b/dist/lib/graph-cache.d.ts
@@ -2,19 +2,4 @@ import { type Graph } from "./graph.js";
 export type VisitToken = object;
 export declare const REVALIDATE_AFTER_MS = 100;
 export declare function stampIsAmbiguous(mtimeMs: number, builtAt: number, coarseTimestamps: boolean): boolean;
-/**
- * The graph for `rootDir`, built once per process and revalidated once per lint
- * pass.
- *
- * `visitToken` should be `context.sourceCode`: ESLint hands every rule the
- * identical object for one parse of a file and a new object for every subsequent
- * parse, so it is what lets a second rule asking about the same file skip
- * revalidation entirely rather than merely avoid tripping the pass-boundary
- * check (see runRules in ESLint's linter, which builds one shared rule-context
- * base per file and extends it per rule; verified this holds across ESLint 9 and
- * 10, under `--cache`, `lintText`, and a processor splitting one file into
- * several blocks). Omitting it - a direct call from a test, a single-rule setup
- * that only ever asks once per file - keeps the original, more conservative
- * behaviour, where every repeat of a file counts as a new pass.
- */
 export declare function getGraph(rootDir: string, ignoreGlobs: string[], currentFile: string, visitToken?: VisitToken): Graph;

--- a/dist/lib/graph-cache.js
+++ b/dist/lib/graph-cache.js
@@ -3,11 +3,6 @@ import { safeRealpath, safeStat } from "./fs-safe.js";
 import { buildGraphWithConfigs } from "./graph.js";
 import { findTsconfig } from "./resolve.js";
 import { isInGraphScope, isSourceFile } from "./scope.js";
-// Upper bound on how long a stale graph can survive a sequence of lints that
-// never revisits a file. Well below the time between a human edit and the next
-// lint, and far above the gap between two files in one pass. Exported so a test
-// asserting behaviour at the boundary sleeps against the real value rather than
-// a copy that silently stops matching if this changes.
 export const REVALIDATE_AFTER_MS = 100;
 const cache = new Map();
 function cacheKey(rootDir, ignoreGlobs) {
@@ -41,11 +36,6 @@ function stampConfigs(configPaths) {
     }
     return stamps;
 }
-// On a filesystem that reports whole-second timestamps, a write landing in the
-// same second as the build is indistinguishable from one that preceded it, so
-// such a stamp cannot be trusted. Comparing against the build time rather than
-// against "now" is what makes this exact: keying off the age of the mtime gave a
-// window that shrank to nothing for a write late in a second.
 export function stampIsAmbiguous(mtimeMs, builtAt, coarseTimestamps) {
     if (!coarseTimestamps) {
         return false;
@@ -54,9 +44,6 @@ export function stampIsAmbiguous(mtimeMs, builtAt, coarseTimestamps) {
     return mtimeMs >= buildSecond && mtimeMs < buildSecond + 1000;
 }
 function tsconfigNeedsRebuild(snapshot, rootDir) {
-    // Resolved first: the stored path came from the resolved root, so comparing a
-    // raw symlinked root found a different config every time and rebuilt the
-    // whole graph on every lint.
     const currentPath = findTsconfig(safeRealpath(rootDir) ?? rootDir);
     const previousPath = snapshot.configs[0]?.path;
     if (currentPath !== previousPath) {
@@ -67,10 +54,6 @@ function tsconfigNeedsRebuild(snapshot, rootDir) {
         return (stat?.mtimeMs ?? 0) !== stamp.mtimeMs;
     });
 }
-// Every tracked file, not only the one being linted. ESLint lints one file at a
-// time, so checking just that file left an edit to any other file invisible: the
-// report neither appeared nor - worse - went away once the user fixed the import
-// in the file that caused it. Deletions were never noticed at all.
 function trackedFilesChanged(snapshot) {
     for (const [file, prev] of snapshot.stamps) {
         const stat = safeStat(file);
@@ -86,10 +69,6 @@ function trackedFilesChanged(snapshot) {
     }
     return false;
 }
-// Mirrors what walkDir would have collected, via the one statement of graph
-// membership in scope.ts. Anything walkDir skips must be skipped here too, or
-// linting one such file rebuilds the whole graph every time because its stamp is
-// never recorded.
 function isProductionGraphFile(currentFile, rootDir, ignoreGlobs) {
     const realRoot = safeRealpath(rootDir);
     if (realRoot === undefined || !isSourceFile(currentFile)) {
@@ -97,33 +76,12 @@ function isProductionGraphFile(currentFile, rootDir, ignoreGlobs) {
     }
     return isInGraphScope(path.relative(realRoot, currentFile), ignoreGlobs);
 }
-// Recognises a second rule asking about the same parse. Bounded by
-// REVALIDATE_AFTER_MS because token identity proves "same SourceCode object",
-// not "same moment": Linter#verify accepts a SourceCode instance and passes its
-// identity straight through to context.sourceCode, so a host that retains one
-// and re-verifies it keeps the token alive indefinitely. Unbounded, that froze
-// the graph permanently - every later verify matched the token, so neither the
-// tsconfig check nor the tracked-file sweep ever ran again, and a report could
-// not be made to go away by editing any file other than the one being linted.
-// The bound costs nothing inside a real parse (two rules are microseconds apart)
-// and puts the worst case back on the same footing as every other staleness
-// window here.
 function isSameParse(pass, currentFile, visitToken) {
     return (visitToken !== undefined &&
         pass.lastFile === currentFile &&
         pass.lastToken?.deref() === visitToken &&
         Date.now() - pass.validatedAt < REVALIDATE_AFTER_MS);
 }
-/**
- * Whether the cached graph can be handed back as-is.
- *
- * Order matters. A second rule's call inside the very same parse cannot have
- * observed a tsconfig edit or a tracked-file change that the first rule's call
- * did not already validate, so `isSameParse` comes first and skips both sweeps
- * entirely - `tsconfigNeedsRebuild`'s realpath + findTsconfig walk + config
- * stats, and the once-per-pass stamp sweep with its own realpath - rather than
- * merely avoiding the pass-boundary bookkeeping.
- */
 function isFresh(entry, currentFile, visitToken, rootDir, ignoreGlobs) {
     const { snapshot, pass } = entry;
     if (isSameParse(pass, currentFile, visitToken)) {
@@ -132,10 +90,6 @@ function isFresh(entry, currentFile, visitToken, rootDir, ignoreGlobs) {
     if (tsconfigNeedsRebuild(snapshot, rootDir)) {
         return false;
     }
-    // Validate the tracked set once per pass: seeing a file again means a new pass
-    // began, and the elapsed-time bound covers passes that never revisit a file.
-    // Any repeat of currentFile that reaches here is a genuine new pass, because
-    // isSameParse already absorbed a second rule re-checking the same file.
     const now = Date.now();
     if (pass.visited.has(currentFile) ||
         now - pass.validatedAt >= REVALIDATE_AFTER_MS) {
@@ -146,36 +100,16 @@ function isFresh(entry, currentFile, visitToken, rootDir, ignoreGlobs) {
         }
     }
     pass.visited.add(currentFile);
-    // No stamp means the file was created since the build, so the graph does not
-    // know about it yet.
     if (snapshot.stamps.has(currentFile)) {
         return true;
     }
     return !isProductionGraphFile(currentFile, rootDir, ignoreGlobs);
 }
-// One step, because the pair is meaningless apart: a lastFile without its
-// lastToken (or vice versa) is a same-parse hit waiting to be claimed by the
-// wrong caller.
 function markVisit(pass, currentFile, visitToken) {
     pass.lastFile = currentFile;
     pass.lastToken =
         visitToken === undefined ? undefined : new WeakRef(visitToken);
 }
-/**
- * The graph for `rootDir`, built once per process and revalidated once per lint
- * pass.
- *
- * `visitToken` should be `context.sourceCode`: ESLint hands every rule the
- * identical object for one parse of a file and a new object for every subsequent
- * parse, so it is what lets a second rule asking about the same file skip
- * revalidation entirely rather than merely avoid tripping the pass-boundary
- * check (see runRules in ESLint's linter, which builds one shared rule-context
- * base per file and extends it per rule; verified this holds across ESLint 9 and
- * 10, under `--cache`, `lintText`, and a processor splitting one file into
- * several blocks). Omitting it - a direct call from a test, a single-rule setup
- * that only ever asks once per file - keeps the original, more conservative
- * behaviour, where every repeat of a file counts as a new pass.
- */
 export function getGraph(rootDir, ignoreGlobs, currentFile, visitToken) {
     const key = cacheKey(rootDir, ignoreGlobs);
     const cached = cache.get(key);
@@ -186,8 +120,6 @@ export function getGraph(rootDir, ignoreGlobs, currentFile, visitToken) {
     }
     const { graph, configPaths } = buildGraphWithConfigs(rootDir, ignoreGlobs);
     const stamps = stampFiles(graph.files);
-    // One clock read: the build and its first validation are the same event, and
-    // two Date.now() calls could straddle a millisecond boundary.
     const now = Date.now();
     const entry = {
         snapshot: {

--- a/dist/lib/graph.d.ts
+++ b/dist/lib/graph.d.ts
@@ -1,35 +1,9 @@
 import { type ResolutionSettings } from "./resolve.js";
-/**
- * Readonly because six indexes are derived from a graph and memoised against
- * the graph object for its whole lifetime (see derived.ts): mutating `files` or
- * `importers` in place would silently desync every one of them. A changed tree
- * produces a NEW graph - which is also what drops the old indexes, since
- * nothing invalidates them.
- */
 export interface Graph {
     readonly importers: ReadonlyMap<string, readonly string[]>;
     readonly files: readonly string[];
 }
-/**
- * Whether the graph contains this exact path.
- *
- * Exact on purpose: a caller asking "does the model know this module" is
- * checking a path it got from the graph or from `collectReExports`, and folding
- * would answer for a different file. Use `canonicalGraphPath` first when the
- * path came from a specifier instead.
- */
 export declare function graphHasFile(graph: Graph, filePath: string): boolean;
-/**
- * The graph's own spelling of a resolved path, or the path unchanged when
- * nothing in the graph matches it.
- *
- * `resolveSpecifier` hands back a path built from the specifier's own text, and
- * `fs.realpathSync` (what `safeRealpath` uses) neither folds case on macOS - only
- * its `.native` variant does - nor normalizes Unicode on any platform. So a path
- * that resolved perfectly well can still differ byte-for-byte from the one the
- * walk recorded. Callers that key off a file's directory (gates) need the
- * recorded spelling or they miss real boundaries and invent fake ones.
- */
 export declare function canonicalGraphPath(graph: Graph, filePath: string): string;
 export declare const getGraphResolutionSettings: ((graph: Graph) => ResolutionSettings) & {
     prime: (graph: Graph, value: ResolutionSettings) => void;

--- a/dist/lib/graph.js
+++ b/dist/lib/graph.js
@@ -5,86 +5,23 @@ import { safeReadFile, safeRealpath } from "./fs-safe.js";
 import { extractSpecifiers } from "./parse.js";
 import { createResolutionSettings, resolveSpecifier } from "./resolve.js";
 import { collectSourceFiles } from "./walk.js";
-// Exact graph membership, memoised and primed by the builder. It is not part of
-// Graph itself for the same reason none of the other indexes are: a graph is the
-// raw pair of tables, and everything derived from it lives in a weak table keyed
-// on that pair (see derived.ts).
 const graphFileSet = derivedFromGraph((graph) => new Set(graph.files));
-/**
- * Whether the graph contains this exact path.
- *
- * Exact on purpose: a caller asking "does the model know this module" is
- * checking a path it got from the graph or from `collectReExports`, and folding
- * would answer for a different file. Use `canonicalGraphPath` first when the
- * path came from a specifier instead.
- */
 export function graphHasFile(graph, filePath) {
     return graphFileSet(graph).has(filePath);
 }
-// The two axes on which a resolved path can disagree with the graph's own
-// spelling while still naming the same file on disk:
-//
-// - Unicode normalization, always. `readdir` reports whatever form the
-//   filesystem stores, while a specifier carries whatever form the author's
-//   editor wrote, and `realpath` preserves it rather than converting. macOS
-//   happily opens either, so "Café/inner.ts" written NFD resolves to a real
-//   file whose graph key is NFC - different bytes, same file. This is not
-//   case-sensitivity-dependent, so it is folded on every platform.
-// - Case, only where the filesystem ignores it. Folding case on a
-//   case-sensitive volume would merge two genuinely distinct files.
 function foldGraphPath(filePath) {
     const normalized = filePath.normalize("NFC");
     return ts.sys.useCaseSensitiveFileNames
         ? normalized
         : normalized.toLowerCase();
 }
-// Graph files indexed by their folded key (see foldGraphPath), for recovering
-// the graph's own spelling of a path that points at the same file by a different
-// one. Built on demand rather than primed by buildGraphWithConfigs: the map that
-// function builds for edge recovery is keyed on lower case alone, which is a
-// different key from this one, so the two cannot be shared.
 const graphFilesByFoldedPath = derivedFromGraph((graph) => new Map(graph.files.map((file) => [foldGraphPath(file), file])));
-/**
- * The graph's own spelling of a resolved path, or the path unchanged when
- * nothing in the graph matches it.
- *
- * `resolveSpecifier` hands back a path built from the specifier's own text, and
- * `fs.realpathSync` (what `safeRealpath` uses) neither folds case on macOS - only
- * its `.native` variant does - nor normalizes Unicode on any platform. So a path
- * that resolved perfectly well can still differ byte-for-byte from the one the
- * walk recorded. Callers that key off a file's directory (gates) need the
- * recorded spelling or they miss real boundaries and invent fake ones.
- */
 export function canonicalGraphPath(graph, filePath) {
-    // An exact member of graph.files is already in the graph's spelling, so
-    // folding it would be a rewrite rather than a recovery - the same precedence
-    // buildGraphWithConfigs applies to resolveSpecifier's result. Two files can
-    // share one folded key (differing only by case on a filesystem that ignores
-    // case, or only by normalization on one that does not) and the map keeps
-    // whichever came last, so without this guard one of them silently becomes the
-    // other: an internal `Foo/Index.ts` folds onto the door `Foo/index.ts` and its
-    // crossing vanishes, and the door itself can fold onto an internal file and be
-    // reported as reaching past itself.
     if (graphFileSet(graph).has(filePath)) {
         return filePath;
     }
     return graphFilesByFoldedPath(graph).get(foldGraphPath(filePath)) ?? filePath;
 }
-// Total, not a bare lookup: resolveSpecifier's settings parameter is optional
-// and silently falls back to a lenient default with no project `paths`, so a
-// caller that tolerated `undefined` here would resolve every aliased import
-// to nothing without anything looking broken. The only miss in practice is a
-// graph built from buildGraphWithConfigs' missing-root early return, which
-// has no files to resolve specifiers for anyway.
-//
-// Unprimed graphs get the same no-project settings: walking from cwd or `"."`
-// would pick up whatever tsconfig happens to be nearby (including this repo's
-// when tests run here) and silently attach paths a graph that was never built
-// never earned.
-//
-// The settings carry a TypeScript module resolution cache, so keeping them for
-// the graph's lifetime is the point rather than a bonus. When that lifetime ends
-// is entirely up to the graph cache's own revalidation (see graph-cache.ts).
 function noProjectResolutionSettings() {
     const resolutionOptions = {
         moduleResolution: ts.ModuleResolutionKind.Bundler,
@@ -107,9 +44,6 @@ export function buildGraphWithConfigs(rootDir, ignoreGlobs) {
     }
     const files = collectSourceFiles(resolvedRoot, ignoreGlobs);
     const fileSet = new Set(files);
-    // On a case-insensitive filesystem the compiler resolves "./Helper" against
-    // helper.ts but hands back the path as written, which matched nothing here and
-    // silently dropped the edge. Recover the real casing.
     const filesByLowerCase = ts.sys.useCaseSensitiveFileNames
         ? undefined
         : new Map(files.map((file) => [file.toLowerCase(), file]));
@@ -129,9 +63,6 @@ export function buildGraphWithConfigs(rootDir, ignoreGlobs) {
             const target = fileSet.has(resolved)
                 ? resolved
                 : filesByLowerCase?.get(resolved.toLowerCase());
-            // A file importing itself says nothing about ownership, and the
-            // case-insensitive fallback would otherwise invent such an edge from a
-            // wrong-case self import.
             if (target === undefined || target === file) {
                 continue;
             }
@@ -146,12 +77,6 @@ export function buildGraphWithConfigs(rootDir, ignoreGlobs) {
     }
     const graph = { importers, files };
     getGraphResolutionSettings.prime(graph, settings);
-    // Reuses the member set just built for edge recovery, which is the one index
-    // canonicalGraphPath needs that is known equal here for free. Its folded index
-    // is deliberately not primed from `filesByLowerCase`: that map is keyed on
-    // lower case alone, whereas the fold also normalizes Unicode and skips the
-    // lower-casing entirely on a case-sensitive filesystem, so they are different
-    // keys and sharing them would reintroduce the mismatch this exists to close.
     graphFileSet.prime(graph, fileSet);
     return { graph, configPaths: settings.configPaths };
 }

--- a/dist/lib/owners.d.ts
+++ b/dist/lib/owners.d.ts
@@ -5,9 +5,7 @@ export interface OwnershipContext {
     layerDirs: string[];
 }
 export interface ReExports {
-    /** Sibling modules in the same directory, one entry per module. */
     local: string[];
-    /** Every re-exported module, including modules from elsewhere. */
     total: number;
 }
 export declare function collectReExports(indexFile: string, dir: string, graph: Graph): ReExports;

--- a/dist/lib/owners.js
+++ b/dist/lib/owners.js
@@ -16,23 +16,8 @@ export function collectReExports(indexFile, dir, graph) {
         return { local: [], total: 0 };
     }
     const sourceFile = parseSourceFile(indexFile, content);
-    // Resolving without these silently drops every aliased re-export: the
-    // fallback inside resolveSpecifier carries no project `paths` and no
-    // baseUrl, so "@/Foo/Bar" named no sibling and one tsconfig alias
-    // reclassified the barrel - and with it every finding downstream of
-    // getColocationConsumers.
     const settings = getGraphResolutionSettings(graph);
-    // Keyed by module, not by declaration: the idiomatic value + type split
-    // ("export { x } from './X'; export type { T } from './X';") re-exports one
-    // sibling and must not look like a two-module namespace barrel.
     const local = new Set();
-    // Keyed by resolved module where there is one, and by specifier text only
-    // where there is not, so a re-export that does not resolve (a bare package, a
-    // types-only module) still marks this index as an aggregator while two
-    // spellings of one module count once. Keying on the text alone made "./Bar"
-    // plus "./Bar.js" - or, on a case-insensitive disk, "./Bar" plus "./bar" - an
-    // aggregator, which suppressed mismatchedEntry just as thoroughly as the
-    // double-counted sibling that came with it.
     const modules = new Set();
     const visit = (node) => {
         if (ts.isExportDeclaration(node) &&
@@ -40,22 +25,11 @@ export function collectReExports(indexFile, dir, graph) {
             ts.isStringLiteral(node.moduleSpecifier)) {
             const specifier = node.moduleSpecifier.text;
             const resolved = resolveSpecifier(specifier, dir, settings);
-            // resolveSpecifier builds its answer from the specifier's own text and
-            // realpath folds neither case nor Unicode normalization, so a target that
-            // resolved perfectly well can still be spelled differently from the graph
-            // key for the same file. Only the target needs recovering: realDir and
-            // realIndex come from a path the walk itself recorded.
             const target = resolved === undefined
                 ? undefined
                 : canonicalGraphPath(graph, resolved);
-            // An index re-exporting itself ("export * from './index'") names no
-            // sibling at all.
             if (target === undefined || target !== realIndex) {
                 modules.add(target ?? specifier);
-                // Asked of the resolved file rather than of the specifier's spelling:
-                // a relative-specifier gate here said the same thing for "./Bar" and
-                // the wrong thing for an aliased sibling, which stayed uncounted and
-                // so unbarrelled.
                 if (target !== undefined && path.dirname(target) === realDir) {
                     local.add(target);
                 }
@@ -84,10 +58,6 @@ function isOwnerEntryFile(file, dir, graph) {
     if (base !== "index") {
         return false;
     }
-    // An index makes its directory a module only when the directory is imported
-    // through it. A barrel over loose helpers is not a module boundary: counting
-    // it as one made a shared helper directory an "owner", which both flagged the
-    // files inside it and silenced a standalone owner's private helper.
     return (graph.importers.get(file) ?? []).some((importer) => path.dirname(importer) !== dir);
 }
 function directoryHasMatchingEntry(dir, graph) {
@@ -126,7 +96,6 @@ function buildImports(graph) {
     }
     return imports;
 }
-// Tarjan, iterative so a deep import chain cannot blow the stack.
 function stronglyConnectedIds(nodes, edgesOf) {
     const index = new Map();
     const low = new Map();
@@ -189,11 +158,6 @@ function stronglyConnectedIds(nodes, edgesOf) {
 function getRoots(graph) {
     const imports = buildImports(graph);
     const componentIds = stronglyConnectedIds(graph.files, (file) => imports.get(file) ?? []);
-    // Entry points are whole components, not individual files. Inside a cycle
-    // nothing is importer-free, so asking for zero importers leaves a cyclic
-    // entry with no roots at all and strips the shell exemption from the whole
-    // project; asking each file individually would promote the inner half of a
-    // cycle that something outside imports.
     const importedFromOutside = new Set();
     for (const file of graph.files) {
         const component = componentIds.get(file);
@@ -212,11 +176,6 @@ function getRoots(graph) {
     }
     return roots;
 }
-// Entry points plus what they import directly. Deliberately not configurable and
-// deliberately not transitive: a longer bootstrap chain is expressed by declaring
-// the directories it reaches as layers, which states something true about those
-// modules. Exempting the shell's imports outright would also hide a shell that
-// reaches past a feature's entry into its internals - a real finding.
 export const getShells = derivedFromGraph((graph) => {
     const roots = getRoots(graph);
     const shells = new Set(roots);
@@ -242,9 +201,6 @@ function collectLayerDirs(dir, cwd, rootDir, layerGlobs, out) {
             continue;
         }
         const fullPath = path.join(dir, entry.name);
-        // Matched against both spellings: `ignore` globs are relative to `root`
-        // while these were relative to the working directory, so with root: "src"
-        // the natural glob silently matched nothing.
         const candidates = [
             path.relative(cwd, fullPath).split(path.sep).join("/"),
             path.relative(rootDir, fullPath).split(path.sep).join("/"),
@@ -266,15 +222,6 @@ export function collectLayerDirectories(cwd, layerGlobs, rootDir = cwd) {
     collectLayerDirs(cwd, cwd, rootDir, layerGlobs, dirs);
     return dirs;
 }
-// Memoised against the graph rather than for the life of the process: a layer
-// directory created mid-session used to stay invisible until ESLint restarted,
-// which meant a permanent false privateOutsideOwner on every module inside it.
-// A new directory rebuilds the graph, which drops this entry with it.
-//
-// Two-level, unlike every other index here: the graph does not determine the
-// answer on its own, so the inner map keys the parts that vary per call. Passing
-// them to derivedFromGraph as extra arguments would serve one graph's first
-// answer to every later cwd and glob set.
 const layerDirsByGraph = derivedFromGraph(() => new Map());
 export function resolveLayerDirectories(graph, cwd, layerGlobs, rootDir = cwd) {
     if (layerGlobs.length === 0) {
@@ -304,8 +251,6 @@ export function isLayerPublicModule(filePath, layerDirs) {
     }
     const folderName = path.basename(parent);
     const fileBase = path.basename(filePath, path.extname(filePath));
-    // "index" is an entry everywhere else in the plugin, so a layer folder using
-    // one was told to move somewhere it cannot go.
     return fileBase === folderName || fileBase === "index";
 }
 export function shouldSkipColocation(filePath, ctx) {
@@ -395,10 +340,6 @@ export function getSharedColocationIssue(filePath, ctx) {
     }
     const ownerDirs = [...new Set([...owners.values()].map(ownerDir))];
     const lca = longestCommonAncestor(ownerDirs);
-    // Only a folder owner has a folder to be inside of; a standalone owner's parent
-    // directory belongs to nobody. Every folder owner above the subject counts, not
-    // just the innermost one, so a folder entry buried in an unrelated tree is
-    // still caught by the tree it is buried in.
     const consumerFolderDirs = [...owners.values()]
         .filter((owner) => owner.kind === "folder")
         .map((owner) => owner.path);
@@ -410,14 +351,9 @@ export function getSharedColocationIssue(filePath, ctx) {
         if (!isInsideDir(filePath, dir)) {
             return false;
         }
-        // A folder at or above the common ancestor holds every consumer, so being
-        // inside it is not "tucked inside one owner".
         if (!isInsideDir(dir, lca)) {
             return false;
         }
-        // A folder's own entry is never misplaced within its own folder - there is
-        // nowhere else for it to go. If the folder itself sits in the wrong place,
-        // the folders above it say so, and they are still in this list.
         return !isOwnerEntryFile(filePath, dir, ctx.graph);
     });
     if (containing.length > 0) {

--- a/dist/lib/parse.js
+++ b/dist/lib/parse.js
@@ -15,19 +15,14 @@ function scriptKindFromFileName(fileName) {
     return ts.ScriptKind.TS;
 }
 export function parseSourceFile(fileName, content) {
-    return ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, 
-    /*setParentNodes*/ false, scriptKindFromFileName(fileName));
+    return ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, false, scriptKindFromFileName(fileName));
 }
 function stringLiteralText(node) {
-    // No-substitution templates are as static as quotes. isStringLiteral
-    // rejects them, so one character dropped the graph edge.
     if (node !== undefined && ts.isStringLiteralLike(node)) {
         return node.text;
     }
     return undefined;
 }
-// The specifier this node imports through, or undefined when it imports
-// nothing. `requireIsCjs` decides only whether a bare `require(...)` counts.
 function importedSpecifier(node, requireIsCjs) {
     if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
         return stringLiteralText(node.moduleSpecifier);
@@ -43,8 +38,6 @@ function importedSpecifier(node, requireIsCjs) {
                 node.expression.text === "require"))) {
         return stringLiteralText(node.arguments[0]);
     }
-    // ImportTypeNode is not a CallExpression. Type-position import("./x").T
-    // and typeof import("./x") used to leave the target with no importer.
     if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
         return stringLiteralText(node.argument.literal);
     }
@@ -53,9 +46,6 @@ function importedSpecifier(node, requireIsCjs) {
 export function extractSpecifiers(content, fileName) {
     const sourceFile = parseSourceFile(fileName, content);
     const specifiers = [];
-    // Scope-aware: a `require` bound in an unrelated nested scope used to disable
-    // every require() edge in the file, while a parameter named require must still
-    // shadow it within that function.
     const visit = (node, shadowed) => {
         const requireIsCjs = !(shadowed || scopeBindsRequire(node));
         const specifier = importedSpecifier(node, requireIsCjs);

--- a/dist/lib/paths.d.ts
+++ b/dist/lib/paths.d.ts
@@ -1,19 +1,2 @@
-/**
- * Whether `filePath` sits strictly inside `dir`.
- *
- * One home for a predicate that previously existed in three copies - in
- * `gates.ts`, `owners.ts`, and as `isWithinRoot` in `graph.ts` - each carrying
- * the same defect: appending a separator to a `dir` that already ends in one
- * builds `"//"`, which matches nothing, so a file plainly inside the directory
- * looked outside it. That is reachable rather than theoretical, because
- * `resolveRootDir` returns an absolute `root` verbatim and so `root: "/"`
- * survives all the way down here. Fixing one copy left the other two wrong; the
- * point of this module is that there is nowhere left for them to disagree.
- *
- * Lives on its own rather than in `graph.ts` so that `gates.ts` can use it
- * without the access model depending on the graph or the ownership model, which
- * is what the duplication was originally protecting.
- */
 export declare function isInsideDir(filePath: string, dir: string): boolean;
-/** `isInsideDir`, but a directory also counts as being at itself. */
 export declare function isAtOrInsideDir(filePath: string, dir: string): boolean;

--- a/dist/lib/paths.js
+++ b/dist/lib/paths.js
@@ -1,25 +1,8 @@
 import path from "node:path";
-/**
- * Whether `filePath` sits strictly inside `dir`.
- *
- * One home for a predicate that previously existed in three copies - in
- * `gates.ts`, `owners.ts`, and as `isWithinRoot` in `graph.ts` - each carrying
- * the same defect: appending a separator to a `dir` that already ends in one
- * builds `"//"`, which matches nothing, so a file plainly inside the directory
- * looked outside it. That is reachable rather than theoretical, because
- * `resolveRootDir` returns an absolute `root` verbatim and so `root: "/"`
- * survives all the way down here. Fixing one copy left the other two wrong; the
- * point of this module is that there is nowhere left for them to disagree.
- *
- * Lives on its own rather than in `graph.ts` so that `gates.ts` can use it
- * without the access model depending on the graph or the ownership model, which
- * is what the duplication was originally protecting.
- */
 export function isInsideDir(filePath, dir) {
     const prefix = dir.endsWith(path.sep) ? dir : dir + path.sep;
     return filePath.startsWith(prefix);
 }
-/** `isInsideDir`, but a directory also counts as being at itself. */
 export function isAtOrInsideDir(filePath, dir) {
     return filePath === dir || isInsideDir(filePath, dir);
 }

--- a/dist/lib/require-binding.d.ts
+++ b/dist/lib/require-binding.d.ts
@@ -1,15 +1,5 @@
 import type { SourceCode } from "eslint";
 import type * as ESTree from "estree";
 import ts from "typescript";
-/**
- * Whether this TypeScript scope itself binds `require`, shadowing the CJS one.
- * Answered from a bare `ts.SourceFile`, so only the binders visible in the
- * syntax tree count.
- */
 export declare function scopeBindsRequire(node: ts.Node): boolean;
-/**
- * The same question over ESLint's scope chain, which resolves it properly: a
- * `require` bound in an enclosing scope is not the CJS one, so it is not an edge
- * - unless it was bound by createRequire, which is.
- */
 export declare function requireIsShadowed(sourceCode: SourceCode, node: ESTree.Node): boolean;

--- a/dist/lib/require-binding.js
+++ b/dist/lib/require-binding.js
@@ -1,21 +1,4 @@
 import ts from "typescript";
-/**
- * One policy, two ASTs.
- *
- * `require` is only an import edge when the name really is Node's CJS require: a
- * local binding shadows it, and EVERY def of that binding must be
- * `createRequire(...)` for the name to still be the real thing. There are
- * necessarily two implementations of that one rule, because the two callers hold
- * incompatible ASTs and neither can borrow the other's: `parse.ts` answers it
- * over a bare TypeScript `SourceFile` (no binder, no program, no scope manager)
- * for every file in the tree, while `rules/entry.ts` answers it over ESLint's
- * scope manager for the one file being linted, and must report on a positioned
- * node. Keeping both in this one file is what stops them drifting apart
- * silently. They already have: see AGENTS.md's Known issues for the binders the
- * TypeScript-side walk cannot see.
- */
-// Both spellings count as the constructor: `createRequire(...)` and
-// `mod.createRequire(...)`.
 const CREATE_REQUIRE = "createRequire";
 const REQUIRE = "require";
 function tsIsCreateRequireCall(node) {
@@ -44,11 +27,6 @@ function bindsName(name, target) {
     }
     return name.elements.some((element) => ts.isBindingElement(element) ? bindsName(element.name, target) : false);
 }
-/**
- * Whether this TypeScript scope itself binds `require`, shadowing the CJS one.
- * Answered from a bare `ts.SourceFile`, so only the binders visible in the
- * syntax tree count.
- */
 export function scopeBindsRequire(node) {
     if (ts.isFunctionLike(node)) {
         if (node.parameters.some((p) => bindsName(p.name, REQUIRE))) {
@@ -69,8 +47,6 @@ export function scopeBindsRequire(node) {
                 if (!bindsName(declaration.name, REQUIRE)) {
                     continue;
                 }
-                // `const require = createRequire(import.meta.url)` IS the real require,
-                // so its calls are genuine edges.
                 if (tsIsCreateRequireCall(declaration.initializer)) {
                     continue;
                 }
@@ -84,30 +60,11 @@ export function scopeBindsRequire(node) {
     }
     return false;
 }
-/**
- * The same question over ESLint's scope chain, which resolves it properly: a
- * `require` bound in an enclosing scope is not the CJS one, so it is not an edge
- * - unless it was bound by createRequire, which is.
- */
 export function requireIsShadowed(sourceCode, node) {
     let scope = sourceCode.getScope(node);
     while (scope !== null) {
         const variable = scope.variables.find((entry) => entry.name === REQUIRE);
-        // An ambient/global `require` (Node's CJS globals, a `.cjs` file's
-        // default sourceType, `globals: globals.node`) has no defs at all - it
-        // is not a local binding, so it must not be treated as shadowing the
-        // CJS one. Only a variable with an actual definition here (parameter,
-        // `const`, `function require() {}`, ...) can shadow it.
         if (variable !== undefined && variable.defs.length > 0) {
-            // Every def has to be a createRequire binding for the name to still be
-            // the real require. `defs.some` was order-blind: with `var require =
-            // createRequire(url)` followed by `var require = 1`, the call loads
-            // nothing at all, yet a some() check still called it genuine and
-            // reported a crossing that cannot happen. Requiring all of them trades
-            // that false positive for a false negative in the mirror case (plain
-            // first, createRequire second) - the right way round for a lint rule,
-            // and just as rare, since both need `require` declared twice in one
-            // scope.
             return !variable.defs.every((def) => {
                 const declarator = def.node;
                 return (declarator.type === "VariableDeclarator" &&

--- a/dist/lib/resolve.js
+++ b/dist/lib/resolve.js
@@ -2,9 +2,6 @@ import path from "node:path";
 import ts from "typescript";
 import { safeRealpath, safeStat } from "./fs-safe.js";
 import { isSourceFile, SOURCE_EXTS } from "./scope.js";
-// One lenient policy for every specifier, whatever the project configures for
-// tsc: bundler-style resolution accepts extensionless imports and maps
-// "./x.js" onto x.ts, which is how these projects are actually built.
 const RESOLUTION_OVERRIDES = {
     moduleResolution: ts.ModuleResolutionKind.Bundler,
     allowJs: true,
@@ -17,8 +14,6 @@ function loadCompilerOptions(rootDir) {
     if (configPath === undefined) {
         return { options: {}, configPaths: [] };
     }
-    // getParsedCommandLineOfConfigFile (rather than readConfigFile) is what
-    // follows "extends", so paths declared in a base config are honoured.
     const parsed = ts.getParsedCommandLineOfConfigFile(configPath, {}, {
         ...ts.sys,
         onUnRecoverableConfigFileDiagnostic: () => { },
@@ -79,13 +74,6 @@ function probeResolvedPath(base) {
     }
     return undefined;
 }
-// The compiler will not try .cts/.cjs for an extensionless specifier, and for a
-// non-relative one there is no path left to probe once it gives up - so the
-// mapping is expanded here, longest prefix first, exactly as tsc orders it.
-// tsc picks exactly one pattern - an exact key first, otherwise the longest
-// matching prefix - and if that pattern's targets do not exist the specifier is
-// simply unresolved. Trying every matching pattern invented edges the compiler
-// refuses.
 function bestPathPattern(specifier, paths) {
     if (Object.prototype.hasOwnProperty.call(paths, specifier)) {
         return specifier;
@@ -130,12 +118,6 @@ function aliasCandidates(specifier, options) {
     const matched = star === -1
         ? ""
         : specifier.slice(star, specifier.length - (pattern.length - star - 1));
-    // tsc reports a diagnostic for a malformed `paths` entry but still hands the
-    // raw value straight back in options.paths, so a one-bracket typo
-    // (`"@/*": "src/*"` instead of `["src/*"]`) or a non-string target arrives
-    // here exactly as written. Taken on trust, that threw a TypeError out of the
-    // rule and killed the entire lint run with no results at all - the one thing
-    // the filesystem handling everywhere else is careful never to do.
     const targets = paths[pattern];
     if (!Array.isArray(targets)) {
         return [];
@@ -166,8 +148,6 @@ export function resolveSpecifier(specifier, fromDir, settings) {
             return resolved;
         }
     }
-    // Extensions the compiler will not resolve on its own (.cts, .cjs) still
-    // resolve here, for relative and aliased specifiers alike.
     if (specifier.startsWith(".")) {
         return probeResolvedPath(path.resolve(fromDir, specifier));
     }

--- a/dist/lib/root.js
+++ b/dist/lib/root.js
@@ -1,15 +1,5 @@
 import path from "node:path";
 import { safeStat } from "./fs-safe.js";
-// A relative root is resolved against the working directory, but ESLint may be
-// invoked from anywhere - a subdirectory, via lint-staged, from a monorepo script.
-// Resolving "src" against cwd alone meant the directory was simply not found from
-// a subdirectory, and a missing root reports nothing, so the rules go quiet
-// instead of complaining. Walk up until the configured root exists.
-//
-// The returned path is a candidate, not a guarantee: when nothing matched during
-// the walk, resolveRootDir falls back to the plain cwd-relative resolution, which
-// may not exist on disk. Callers must degrade to no findings rather than assume
-// the result is real.
 function isProjectBoundary(dir) {
     return (safeStat(path.join(dir, "package.json")) !== undefined ||
         safeStat(path.join(dir, ".git")) !== undefined);
@@ -24,10 +14,6 @@ export function resolveRootDir(rootOption, cwd) {
         if (safeStat(candidate)?.isDirectory() === true) {
             return candidate;
         }
-        // Stop at the project it belongs to. Unbounded, the walk would happily
-        // resolve root: "src" to a checkout's parent directory that happens to be
-        // called src, taking unrelated projects into the graph and making the
-        // findings depend on where the repository sits on disk.
         if (isProjectBoundary(dir)) {
             break;
         }

--- a/dist/lib/scope.d.ts
+++ b/dist/lib/scope.d.ts
@@ -5,15 +5,4 @@ export declare function isTestFile(relPath: string): boolean;
 export declare function matchesIgnore(relPath: string, ignoreGlobs: string[]): boolean;
 export declare function isOutsideRoot(relPath: string): boolean;
 export declare function isExcludedPath(relPath: string, ignoreGlobs: string[]): boolean;
-/**
- * Whether a path relative to the root names a file the walk would have
- * collected. The one statement of graph membership: the rules ask it whether the
- * linted file is a subject at all and whether a resolved target is in the model,
- * and the graph cache asks it whether an unstamped file is one the walk should
- * have picked up.
- *
- * Four inline copies of this disjunction is exactly how `isInsideDir` came to
- * exist in three copies sharing one defect - fixing one left the others wrong.
- * Do not reintroduce a local copy.
- */
 export declare function isInGraphScope(relPath: string, ignoreGlobs: string[]): boolean;

--- a/dist/lib/scope.js
+++ b/dist/lib/scope.js
@@ -25,8 +25,6 @@ export function isSourceFile(p) {
     }
     return SOURCE_EXTS.some((ext) => p.endsWith(ext));
 }
-// Takes a path relative to the root: given an absolute one, a `__tests__`
-// directory anywhere ABOVE the project would have disabled the rule entirely.
 export function isTestFile(relPath) {
     return (relPath.split(path.sep).includes("__tests__") ||
         /\.(test|spec)\./.test(path.basename(relPath)));
@@ -38,15 +36,9 @@ export function matchesIgnore(relPath, ignoreGlobs) {
 export function isOutsideRoot(relPath) {
     return (relPath === "" ||
         relPath === ".." ||
-        // Not startsWith("..") - a directory named "..data" (Kubernetes mounts one)
-        // is inside the root.
         relPath.startsWith(".." + path.sep) ||
         path.isAbsolute(relPath));
 }
-// A file is excluded when it, or any directory above it, is skipped or ignored -
-// which is what walkDir does as it descends. Checking only the file's own path
-// let an ignore glob naming a directory ("gen" rather than "gen/**") pass, and
-// never consulted SKIP_DIRS at all.
 export function isExcludedPath(relPath, ignoreGlobs) {
     const segments = relPath.split(path.sep);
     for (let i = 1; i <= segments.length; i += 1) {
@@ -59,17 +51,6 @@ export function isExcludedPath(relPath, ignoreGlobs) {
     }
     return false;
 }
-/**
- * Whether a path relative to the root names a file the walk would have
- * collected. The one statement of graph membership: the rules ask it whether the
- * linted file is a subject at all and whether a resolved target is in the model,
- * and the graph cache asks it whether an unstamped file is one the walk should
- * have picked up.
- *
- * Four inline copies of this disjunction is exactly how `isInsideDir` came to
- * exist in three copies sharing one defect - fixing one left the others wrong.
- * Do not reintroduce a local copy.
- */
 export function isInGraphScope(relPath, ignoreGlobs) {
     return (!isOutsideRoot(relPath) &&
         !isTestFile(relPath) &&

--- a/dist/lib/subject.d.ts
+++ b/dist/lib/subject.d.ts
@@ -1,51 +1,13 @@
 import type { Rule } from "eslint";
 import type { Graph } from "./graph.js";
-/**
- * The file a rule has been asked about, once it is known to be one the model can
- * talk about at all.
- *
- * Both rules opened with the same preamble - default the root, resolve it
- * against a cwd that may be anywhere, realpath it and the linted file, tolerate
- * either being absent, then reject the file for being outside the root, a test,
- * or excluded. Two copies of that is how `isInsideDir` came to exist in three
- * copies sharing one defect; do not reintroduce a local one.
- */
 export interface Subject {
-    /**
-     * The configured root, resolved but deliberately NOT realpathed: it is half
-     * the graph cache key, so realpathing it here would give a symlinked root a
-     * second cache entry and change when the graph is rebuilt.
-     */
     readonly rootDir: string;
-    /** The same root, realpathed - what every path comparison uses. */
     readonly realRootDir: string;
-    /** The linted file, realpathed. */
     readonly file: string;
-    /**
-     * The same file under the path ESLint handed over, NOT realpathed. Every path
-     * comparison uses `file`; this exists because ownership's `mismatchedEntry`
-     * decision asks "is this an index?" of the linted path and always has, and a
-     * symlink named `index.ts` pointing at a differently-named module answers the
-     * two questions differently. Do not reach for it for anything else.
-     */
     readonly lintedPath: string;
     readonly ignore: string[];
-    /**
-     * Built on first use and memoised for this file, so a file that asks nothing
-     * never pays for the graph and a file that asks repeatedly pays once. Supplies
-     * `context.sourceCode` as `getGraph`'s visit token, which is what lets both
-     * rules share one revalidation of the same parse.
-     */
     graph(): Graph;
-    /** Whether a resolved path is a file the model can talk about. */
     covers(filePath: string): boolean;
-    /** Posix-relative to the root, for report message data. */
     display(filePath: string): string;
 }
-/**
- * `undefined` when there is nothing to say about this file: a root that is not
- * on disk, a linted path that is not a real file (processors,
- * `--stdin-filename`, a file deleted mid-run), or a file outside the model.
- * Tolerant rather than throwing, since none of those is the user's mistake.
- */
 export declare function resolveSubject(context: Rule.RuleContext): Subject | undefined;

--- a/dist/lib/subject.js
+++ b/dist/lib/subject.js
@@ -3,12 +3,6 @@ import { safeRealpath } from "./fs-safe.js";
 import { getGraph } from "./graph-cache.js";
 import { resolveRootDir } from "./root.js";
 import { isInGraphScope, isSourceFile } from "./scope.js";
-/**
- * `undefined` when there is nothing to say about this file: a root that is not
- * on disk, a linted path that is not a real file (processors,
- * `--stdin-filename`, a file deleted mid-run), or a file outside the model.
- * Tolerant rather than throwing, since none of those is the user's mistake.
- */
 export function resolveSubject(context) {
     const options = (context.options[0] ?? {});
     const ignore = options.ignore ?? [];
@@ -21,10 +15,6 @@ export function resolveSubject(context) {
     if (realRootDir === undefined || file === undefined) {
         return undefined;
     }
-    // Deliberate asymmetry: resolved targets are extension-tested by `covers`,
-    // but the linted file is only scope-tested here - the extension check already
-    // happened on the path ESLint handed over, so a `.ts` symlink pointing at a
-    // `.txt` file is still a subject.
     if (!isInGraphScope(path.relative(realRootDir, file), ignore)) {
         return undefined;
     }

--- a/dist/lib/walk.d.ts
+++ b/dist/lib/walk.d.ts
@@ -1,2 +1,1 @@
-/** Every source file under a resolved root, sorted, in the walk's own spelling. */
 export declare function collectSourceFiles(resolvedRoot: string, ignoreGlobs: string[]): string[];

--- a/dist/lib/walk.js
+++ b/dist/lib/walk.js
@@ -4,10 +4,6 @@ import { isAtOrInsideDir } from "./paths.js";
 import { isExcludedPath, isSourceFile, isTestFile, matchesIgnore, SKIP_DIRS, } from "./scope.js";
 function walkDir(dir, rootDir, ignoreGlobs, files, ancestorRealDirs, linkedRealDirs, behindLink) {
     const realDir = safeRealpath(dir);
-    // Guarded per branch rather than globally: two sibling links to one real
-    // directory are both legitimate, and a global set let whichever path was
-    // walked first decide the other's fate - so an ignore glob aimed at a link
-    // erased the real directory too.
     if (realDir === undefined || ancestorRealDirs.has(realDir)) {
         return;
     }
@@ -15,9 +11,6 @@ function walkDir(dir, rootDir, ignoreGlobs, files, ancestorRealDirs, linkedRealD
     for (const entry of safeReaddir(dir)) {
         const fullPath = path.join(dir, entry.name);
         const relPath = path.relative(rootDir, fullPath);
-        // readdir reports a symlink as neither file nor directory, so entries were
-        // dropped here while the resolver followed them happily - a module behind a
-        // linked directory was invisible as a consumer. Stat follows the link.
         const stat = entry.isSymbolicLink() ? safeStat(fullPath) : undefined;
         const isDirectory = entry.isSymbolicLink()
             ? (stat?.isDirectory() ?? false)
@@ -31,20 +24,11 @@ function walkDir(dir, rootDir, ignoreGlobs, files, ancestorRealDirs, linkedRealD
         if (SKIP_DIRS.has(entry.name) || matchesIgnore(relPath, ignoreGlobs)) {
             continue;
         }
-        // Only links (and anything below one) need resolving; on a tree with no
-        // symlinks fullPath is already canonical, because the walk started from the
-        // resolved root.
         const isLink = entry.isSymbolicLink();
         const realPath = isLink || behindLink ? safeRealpath(fullPath) : fullPath;
         if (realPath === undefined) {
             continue;
         }
-        // Links are checked under the path they really point at as well. Anything
-        // resolving outside the root stays out of the graph: such files cannot be
-        // reported (they are outside root) yet would still act as importers and as
-        // owners, which turned a linked-in directory into a phantom second owner and
-        // a symlinked entry file into a directory that no longer had an entry.
-        // Ignoring a directory also cannot be undone by reaching it through a link.
         if (realPath !== fullPath) {
             if (!isAtOrInsideDir(realPath, rootDir)) {
                 continue;
@@ -54,10 +38,6 @@ function walkDir(dir, rootDir, ignoreGlobs, files, ancestorRealDirs, linkedRealD
             }
         }
         if (isDirectory) {
-            // Sibling links to one real directory are both legitimate, but nesting
-            // them makes the walk exponential (2^depth), so each real directory is
-            // entered through a link at most once. Directories reached without a link
-            // are always walked.
             if (isLink) {
                 if (linkedRealDirs.has(realPath)) {
                     continue;
@@ -68,12 +48,10 @@ function walkDir(dir, rootDir, ignoreGlobs, files, ancestorRealDirs, linkedRealD
             continue;
         }
         if (isSourceFile(fullPath) && !isTestFile(relPath)) {
-            // A Set because following symlinks can reach the same real file twice.
             files.add(realPath);
         }
     }
 }
-/** Every source file under a resolved root, sorted, in the walk's own spelling. */
 export function collectSourceFiles(resolvedRoot, ignoreGlobs) {
     const collected = new Set();
     walkDir(resolvedRoot, resolvedRoot, ignoreGlobs, collected, new Set(), new Set(), false);

--- a/dist/rules/entry.js
+++ b/dist/rules/entry.js
@@ -4,17 +4,6 @@ import { canonicalGraphPath, getGraphResolutionSettings } from "../lib/graph.js"
 import { requireIsShadowed } from "../lib/require-binding.js";
 import { resolveSpecifier } from "../lib/resolve.js";
 import { resolveSubject } from "../lib/subject.js";
-/**
- * The specifier this node imports through, or undefined when it is not
- * statically known.
- *
- * A no-substitution template literal is every bit as static as a quoted string -
- * import(`./x`) loads exactly what import("./x") loads - so it is accepted here.
- * Left out, backticks were a one-character way to launder every crossing in a
- * file past a rule whose whole purpose is a ratchet. One with substitutions is
- * not statically known and stays out, as does anything else non-literal
- * (concatenation, `as string`, identifiers).
- */
 function staticSpecifier(source) {
     if (source.type === "Literal") {
         return typeof source.value === "string" ? source.value : undefined;
@@ -26,23 +15,6 @@ function staticSpecifier(source) {
     }
     return undefined;
 }
-/**
- * The gate this specifier reaches past, or undefined when the import is legal.
- *
- * Both the target and the importer go through `canonicalGraphPath`, because
- * fs.realpathSync does not fold case. On the importer side a lower-cased linted
- * path left `isInsideDir` comparing against the gate's real key: it missed, and
- * the file was told to reach into the very directory it lives in - a report whose
- * only fix is to import its own door, i.e. a cycle. On the target side a resolved
- * path carries the specifier's casing, so "./Feature/FEATURE" misses `isEntryFile`
- * and reports a door the author already used, while "./feature/helper" misses the
- * gate key and reports nothing at all.
- *
- * `subject.covers` is also what keeps declaration files out: the walk skips them
- * and they can never be gates, but `resolveSpecifier`'s own probe still finds
- * `types.d.ts` for a "./types.d" specifier - which reported a crossing and named
- * a door that will never re-export the type.
- */
 function crossedGate(specifier, subject) {
     const graph = subject.graph();
     const resolved = resolveSpecifier(specifier, path.dirname(subject.file), getGraphResolutionSettings(graph));
@@ -106,23 +78,9 @@ const rule = {
         };
         return {
             ImportDeclaration: (node) => check(node.source),
-            // No barrel exemption here, unlike ownership's namespace-barrel handling:
-            // that exemption is about where a file belongs, not about whether reaching
-            // through it is legal. A barrel that re-exports a private file under a
-            // public name launders the violation - every downstream consumer of the
-            // barrel then looks innocent - so `export ... from` is checked exactly like
-            // an import. (ownership's predicate is sibling-scoped, so it would not even
-            // recognise a cross-directory barrel like this one.)
             ExportNamedDeclaration: (node) => check(node.source),
             ExportAllDeclaration: (node) => check(node.source),
             ImportExpression: (node) => check(node.source),
-            // `import("./x").T` and `typeof import("./x")` are TSImportType, not
-            // ImportExpression. Without this visitor the rule's answer depended on
-            // which of two equivalent type-import spellings the author picked:
-            // `import type { T } from "./x"` was gated and the inline form - what
-            // generated code and files avoiding top-level imports emit - was not,
-            // contradicting the "type-only imports treated like value imports"
-            // invariant.
             TSImportType: (node) => check(node.source ?? node.argument?.literal),
             TSImportEqualsDeclaration: (node) => {
                 if (node.moduleReference?.type === "TSExternalModuleReference") {
@@ -132,9 +90,6 @@ const rule = {
             CallExpression: (node) => {
                 if (node.callee.type !== "Identifier" ||
                     node.callee.name !== "require" ||
-                    // parse.ts takes arguments[0] at any arity, so require("./x", opts) is
-                    // still an edge there; narrowed to exactly one argument here
-                    // deliberately, since a real CJS require never takes a second one.
                     node.arguments.length !== 1 ||
                     requireIsShadowed(context.sourceCode, node)) {
                     return;

--- a/dist/rules/ownership.js
+++ b/dist/rules/ownership.js
@@ -31,15 +31,10 @@ const rule = {
         const layers = options.layers ?? [];
         return {
             Program(node) {
-                // Resolved here rather than in create() for the same reason it always
-                // was: a configured root that does not exist, or a linted path that is
-                // not on disk (processors, --stdin-filename, a file deleted mid-run),
-                // means "nothing to say" rather than a crash.
                 const subject = resolveSubject(context);
                 if (subject === undefined) {
                     return;
                 }
-                // Report on the first statement so eslint-disable comments still apply under ESLint 10.
                 const reportNode = node.body[0] ?? node;
                 for (const messageId of ownershipFindings(subject, context.cwd, layers)) {
                     context.report({ node: reportNode, messageId });

--- a/scripts/check-placement.ts
+++ b/scripts/check-placement.ts
@@ -1,35 +1,3 @@
-/**
- * Placement satisfiability sweep.
- *
- * Every report either rule emits must be fixable. For `ownership` that means:
- * for a given project there has to be *somewhere* the file can live that the
- * rule accepts. Four separate bugs on this project were reports that no
- * location satisfied, so this generates random layouts, places the subject file
- * at every plausible location, and fails if any configuration has no clean
- * placement at all.
- *
- * `colocate/entry` is swept too, for the same property stated its own way:
- * there has to be a *specifier* the importer can use that the rule accepts.
- * Because landing on any door is legal (see "Nested doors count" in
- * docs/agents/entry.md), rewriting the specifier to the named entry always
- * clears the report - unless the door is unreachable from the importer, which
- * happens exactly when the importer already lives inside the module it is being
- * told to enter. Then the only "fix" is for a file to import its own door, i.e.
- * a cycle, and the report is unsatisfiable. That is not hypothetical: the entry
- * rule shipped with such a bug (a wrong-case importer path defeated the
- * inside-the-gate check) and this script could not see it, because it only ever
- * enabled `ownership`.
- *
- * Not part of `npm test` — it runs a few thousand lints. Run it after touching
- * either model:
- *
- *     npm run check:placement
- *
- * Validated against the commit before the fix in ee22223: 51 of 200
- * configurations were unsatisfiable there, 0 afterwards. The entry sweep was
- * validated the same way, by removing `findCrossedGate`'s inside-the-gate check:
- * 34 of 106 entry reports became unsatisfiable, and 0 with it restored.
- */
 import fs from "node:fs";
 import path from "node:path";
 import { ESLint } from "eslint";
@@ -64,7 +32,6 @@ function spec(fromDir: string, target: string): string {
   return rel.startsWith(".") ? rel : `./${rel}`;
 }
 
-/** Writes the whole project with the subject placed at `placement`. */
 function emit(
   dir: string,
   owners: string[],
@@ -84,7 +51,6 @@ function emit(
           subject.name,
           subject.kind === "entry" ? `${subject.name}.ts` : "index.ts",
         );
-  // Consumers import the folder when the subject is an index file.
   const target =
     subject.kind === "index"
       ? path.posix.join(placement, subject.name)
@@ -92,7 +58,6 @@ function emit(
 
   files[subjectPath] = "export const subject = 1;\n";
   if (subject.kind !== "plain") {
-    // Keeps the subject's folder from being a singleton wrapper.
     files[path.posix.join(placement, subject.name, "sibling.ts")] =
       "export const s = 1;\n";
   }
@@ -147,11 +112,8 @@ async function reportsFor(
       {
         files: ["**/*.ts"],
         plugins: { p: plugin },
-        // Both rules in one pass: they are independent, and sharing the emitted
-        // tree keeps this sweep the same order of cost it always was.
         rules: {
           "p/ownership": ["error", options],
-          // entry takes no `layers`, so it gets only the options it accepts.
           "p/entry": [
             "error",
             { root: options.root, ...(options.ignore ? { ignore: options.ignore } : {}) },
@@ -181,24 +143,15 @@ async function reportsFor(
   return { ownership, entry };
 }
 
-// "'X' is inside module 'M'; import it through 'E', or move it out of ..."
 const ENTRY_MESSAGE =
   /^'(?<target>[^']+)' is inside module '(?<module>[^']+)'; import it through '(?<entry>[^']+)'/;
 
-/**
- * Why this report cannot be fixed, or undefined when it can be.
- *
- * The suggested edit is "import it through the door". That is available unless
- * the importer is itself inside the module (importing its own door is a cycle)
- * or the importer *is* the door.
- */
 function unsatisfiableEntryReason(report: RuleReport): string | undefined {
   const match = ENTRY_MESSAGE.exec(report.message);
   if (match?.groups === undefined) {
     return `unparseable entry message: ${report.message}`;
   }
   const { module: moduleDir, entry: entryFile } = match.groups;
-  // Reports are relative to `root`; the linted file path is relative to cwd.
   const importer = report.file.replace(/^src\//, "");
   if (importer === entryFile) {
     return `importer IS the named door '${entryFile}'`;
@@ -261,8 +214,6 @@ for (let n = 0; n < CONFIGS; n += 1) {
       clean += 1;
     }
 
-    // Every entry report in the whole tree, not just the subject's: the rule
-    // reports on the importer, so the interesting file is rarely the subject.
     for (const report of entry) {
       entryReports += 1;
       const reason = unsatisfiableEntryReason(report);

--- a/src/lib/derived.ts
+++ b/src/lib/derived.ts
@@ -1,29 +1,11 @@
 import type { Graph } from "./graph.js";
 
-/**
- * An index derived from a graph, memoised for exactly as long as that graph
- * lives.
- *
- * Six hand-rolled `WeakMap<Graph, X>` tables repeating one get/undefined/build/
- * set dance had accumulated across three modules (resolution settings, the
- * member set, the folded-path index, gates, shells, layer directories). The
- * lifetime rule all six rely on is worth stating once: a graph is immutable
- * (see `Graph`), so an index built from one stays true for as long as that
- * object exists, and a changed tree produces a *new* graph object whose indexes
- * are therefore empty. Nothing needs invalidating, and nothing here keeps a
- * graph alive - the table is weak.
- */
 export function derivedFromGraph<T, A extends unknown[] = []>(
   build: (graph: Graph, ...args: A) => T,
 ): ((graph: Graph, ...args: A) => T) & {
   prime: (graph: Graph, value: T) => void;
 } {
   const table = new WeakMap<Graph, T>();
-  // Keyed on the graph alone, so extra arguments feed the first build only.
-  // That is honest for a build input the graph itself determines - a graph
-  // object belongs to exactly one (root, ignore) pair - and wrong for anything
-  // that can genuinely differ per call (see resolveLayerDirectories, which keys
-  // those inside its own value).
   const get = (graph: Graph, ...args: A): T => {
     let value = table.get(graph);
     if (value === undefined) {
@@ -32,8 +14,6 @@ export function derivedFromGraph<T, A extends unknown[] = []>(
     }
     return value;
   };
-  // For a caller that already holds the index and would otherwise pay to have
-  // it rebuilt on first use.
   get.prime = (graph: Graph, value: T): void => {
     table.set(graph, value);
   };

--- a/src/lib/findings.ts
+++ b/src/lib/findings.ts
@@ -16,18 +16,6 @@ import {
 } from "./scope.js";
 import type { Subject } from "./subject.js";
 
-/**
- * Everything `colocate/ownership` can say about a file.
- *
- * The two decisions below - is this directory a singleton wrapper, is this index
- * a stand-in for one sibling - lived in the rule until they were moved here, for
- * the reason `gates.ts` exists: a rule file should read as an adapter between
- * ESLint and a model, and the model should be answerable (and testable) without
- * one. `owners.ts` holds the predicates that answer "who owns this file" from the
- * import graph; this module holds what the rule *reports* and in which order,
- * plus the two questions no other caller asks - one of which is a directory walk
- * that never touches the graph at all.
- */
 export type OwnershipFinding =
   | "singletonFolder"
   | "privateOutsideOwner"
@@ -52,14 +40,10 @@ function countSourceFilesRecursive(
   for (const entry of safeReaddir(dir)) {
     const fullPath = path.join(dir, entry.name);
     const relPath = path.relative(rootDir, fullPath);
-    // Files excluded from the graph must not count here either, or an ignored
-    // generated file keeps a wrapper directory looking populated.
     if (matchesIgnore(relPath, ignore)) {
       continue;
     }
 
-    // Symlinks read as neither file nor directory, so a linked subdirectory of
-    // sources used to leave the parent looking like a single-file wrapper.
     const stat = entry.isSymbolicLink() ? safeStat(fullPath) : undefined;
     const isDirectory = entry.isSymbolicLink()
       ? (stat?.isDirectory() ?? false)
@@ -88,27 +72,17 @@ function countSourceFilesRecursive(
   return sourceCount;
 }
 
-// Only beside the file: a stylesheet several directories down is not a
-// companion, and treating it as one silently exempted the wrapper.
 function hasCompanionStylesheet(dir: string): boolean {
   return safeReaddir(dir).some((entry) => {
     if (!isStylesheet(entry.name)) {
       return false;
     }
-    // readdir reports a symlink as neither file nor directory.
     return entry.isSymbolicLink()
       ? (safeStat(path.join(dir, entry.name))?.isFile() ?? false)
       : entry.isFile();
   });
 }
 
-/**
- * Whether `dir` holds nothing but this one file, which could therefore live in
- * the parent directory instead.
- *
- * Answered from disk rather than from the graph on purpose: the question is what
- * the directory contains, and a source file nobody imports is still content.
- */
 function isSingletonWrapperDirectory(
   dir: string,
   filename: string,
@@ -127,14 +101,6 @@ function isSingletonWrapperDirectory(
   return fileBasename === dirName || fileBasename === "index";
 }
 
-/**
- * Whether outside code enters this directory through a barrel that only stands
- * in for one differently-named sibling, so the sibling should be imported (or
- * renamed) directly.
- *
- * Precondition: `indexFile` is an index file (see `ownershipFindings`, which is
- * where that is decided, and why it is decided of the linted path).
- */
 function isMismatchedEntry(indexFile: string, ctx: OwnershipContext): boolean {
   const dir = path.dirname(indexFile);
   if (dir === ctx.rootDir) {
@@ -168,36 +134,17 @@ function isMismatchedEntry(indexFile: string, ctx: OwnershipContext): boolean {
   }
 
   const { local, total } = collectReExports(indexFile, dir, ctx.graph);
-  // An index that also re-exports modules from elsewhere is an aggregator,
-  // not a stand-in for one sibling: the message would name a "named entry
-  // file" that does not exist and dropping the barrel would lose the rest.
   if (local.length !== 1 || total !== 1) {
     return false;
   }
-  // Only modules the graph knows about, so the message cannot point at a
-  // file the user has excluded.
   if (!graphHasFile(ctx.graph, local[0])) {
     return false;
   }
 
-  // Re-exporting the directory's own named entry keeps the folder a real
-  // owner; the barrel only makes `./Foo` resolve to `Foo/Foo.ts`.
   const target = local[0];
   return path.basename(target, path.extname(target)) !== path.basename(dir);
 }
 
-/**
- * Every finding for this file, **in report order**.
- *
- * The order is part of the contract, not an accident of how this reads: the
- * fixture assertions sort, but `check:placement` prints a per-placement matrix of
- * raw sequences and the differential compares raw output, so reordering these
- * four pushes would show up as a diff with no behaviour behind it.
- *
- * Nothing here short-circuits, again deliberately: a file can be a singleton
- * wrapper *and* misplaced relative to its owner, and each report names a
- * different edit.
- */
 export function ownershipFindings(
   subject: Subject,
   cwd: string,
@@ -229,9 +176,6 @@ export function ownershipFindings(
     findings.push(sharedIssue);
   }
 
-  // Asked of `lintedPath` rather than of the realpathed `file`, which is what
-  // this decision has always keyed on - see `Subject.lintedPath`. Everything
-  // below it is about the real directory.
   const lintedBase = path.basename(
     subject.lintedPath,
     path.extname(subject.lintedPath),

--- a/src/lib/fs-safe.ts
+++ b/src/lib/fs-safe.ts
@@ -1,9 +1,5 @@
 import fs from "node:fs";
 
-// The rule runs inside ESLint's process: an uncaught fs error here aborts the
-// user's entire lint run. Every filesystem read goes through these helpers, and
-// a missing or unreadable path always degrades to "skip" rather than throwing.
-
 export function safeRealpath(filePath: string): string | undefined {
   try {
     return fs.realpathSync(filePath);

--- a/src/lib/gates.ts
+++ b/src/lib/gates.ts
@@ -3,26 +3,11 @@ import { derivedFromGraph } from "./derived.js";
 import type { Graph } from "./graph.js";
 import { isInsideDir } from "./paths.js";
 
-/**
- * Structural on purpose. The ownership model only treats an `index` as an entry
- * when code outside the directory imports through it, because a convenience
- * barrel over loose helpers must not redraw ownership boundaries. Access is the
- * other question: a door is a door the moment it exists, or adding one would
- * gate nothing until every consumer had already migrated to it.
- */
 export function isEntryFile(filePath: string): boolean {
   const base = path.basename(filePath, path.extname(filePath));
   return base === "index" || base === path.basename(path.dirname(filePath));
 }
 
-/**
- * Every gated directory mapped to the entry that names it. `index` wins over a
- * directory-named sibling regardless of which the walk sees first: it is the
- * door that makes the bare directory specifier resolve, so it is the shorter
- * fix to suggest. Between two `index` spellings (a migration in progress) the
- * first one in the sorted `graph.files` wins - a real ordering artefact, not a
- * meaningful choice between them.
- */
 export const getGates = derivedFromGraph<ReadonlyMap<string, string>>(
   (graph) => {
     const gates = new Map<string, string>();
@@ -49,33 +34,12 @@ export interface CrossedGate {
   entry: string;
 }
 
-/**
- * The innermost gate containing `target` but not `importer`, or undefined when
- * no boundary separates them.
- *
- * Walking up from the target finds the innermost one directly: a deeper gate
- * always nests inside a shallower one, so an importer inside the deeper gate is
- * inside the shallower one too. The first directory that both gates the target
- * and excludes the importer is therefore the innermost such gate.
- *
- * Precondition: `target`, `importer`, and `rootDir` must already be in the
- * graph's own casing. `rootDir` comes from config and is compared only against
- * itself, so it needs no help. Neither `target` nor `importer` is canonical on
- * arrival on a case-insensitive disk: `resolveSpecifier` hands back whatever
- * casing the specifier text used, and `fs.realpathSync` does not fold case, so
- * the linted path ESLint reports carries whatever casing invoked it. Pass both
- * through `canonicalGraphPath` first - a non-canonical `importer` makes
- * `isInsideDir` miss, which reports a file for reaching into the very
- * directory it lives in and names a fix that would import its own door.
- */
 export function findCrossedGate(
   target: string,
   importer: string,
   graph: Graph,
   rootDir: string,
 ): CrossedGate | undefined {
-  // Checked against the file itself, not against the gate map: a directory with
-  // both doors maps only to its index, and `Dir/Dir.ts` is still a legal target.
   if (isEntryFile(target)) {
     return undefined;
   }

--- a/src/lib/graph-cache.ts
+++ b/src/lib/graph-cache.ts
@@ -4,26 +4,12 @@ import { buildGraphWithConfigs, type Graph } from "./graph.js";
 import { findTsconfig } from "./resolve.js";
 import { isInGraphScope, isSourceFile } from "./scope.js";
 
-// Compared by `===` against a value stored on the graph cache, so it must
-// exclude primitives: `unknown` would let a caller pass a string (a filename,
-// a config hash) that two unrelated single-file passes could share by
-// coincidence, turning "same parse" into a permanent false match instead of
-// the intended one-parse window. `object` rules that out under strict mode
-// (it also excludes `null`, which `unknown` would otherwise admit).
 export type VisitToken = object;
 
-// Upper bound on how long a stale graph can survive a sequence of lints that
-// never revisits a file. Well below the time between a human edit and the next
-// lint, and far above the gap between two files in one pass. Exported so a test
-// asserting behaviour at the boundary sleeps against the real value rather than
-// a copy that silently stops matching if this changes.
 export const REVALIDATE_AFTER_MS = 100;
 
 interface FileStamp {
   mtimeMs: number;
-  // Inode change time, which userland cannot set: it is what catches a
-  // replacement that preserved mtime (cp -p, rsync -t, tar -x, a CI cache
-  // restore) and happens to keep the same size.
   ctimeMs: number;
   size: number;
 }
@@ -33,42 +19,14 @@ interface TsconfigStamp {
   mtimeMs: number;
 }
 
-/** What the graph was built from - everything staleness is judged against. */
 interface Snapshot {
   graph: Graph;
   stamps: Map<string, FileStamp>;
   configs: TsconfigStamp[];
   builtAt: number;
-  // Whole-second mtimes mean the filesystem (HFS+, some network mounts) cannot
-  // distinguish two writes inside the same second, so a same-size edit would
-  // slip past the stamp comparison.
   coarseTimestamps: boolean;
 }
 
-/**
- * How often the snapshot gets checked, which is once per lint pass rather than
- * once per linted file - the sweep is O(files) stats, so doing it per file would
- * be O(files^2) per run.
- *
- * `visited` spots the start of a new pass and `validatedAt` covers a pass that
- * never revisits a file. `lastFile`/`lastToken` recognise a *second rule* asking
- * about the same file within one parse, which `visited` alone reads as a new
- * pass: ESLint runs every enabled rule against a file before moving on, so two
- * rules mean two asks per file, and a bare repeat of a file *path* is not
- * evidence either way, because a later pass can legitimately start over on the
- * very file the previous one ended on. Callers pass `context.sourceCode`, which
- * ESLint hands to every rule as the identical object for one parse and a new
- * object for every subsequent parse.
- *
- * Held as a WeakRef, not a strong reference: a SourceCode (source text + full
- * AST) runs roughly 300x the size of the source file, and this entry otherwise
- * outlives the parse - fine for a long-running eslint CLI process where ESLint
- * itself already pins the last SourceCode, but a problem for a host that
- * discards its ESLint instance while the process keeps running (an editor
- * language server). A collected token derefs to undefined, which compares
- * unequal to everything and falls through to the conservative "treat as a new
- * pass" path - safe, just an extra revalidation.
- */
 interface PassState {
   visited: Set<string>;
   lastFile: string | undefined;
@@ -118,11 +76,6 @@ function stampConfigs(configPaths: string[]): TsconfigStamp[] {
   return stamps;
 }
 
-// On a filesystem that reports whole-second timestamps, a write landing in the
-// same second as the build is indistinguishable from one that preceded it, so
-// such a stamp cannot be trusted. Comparing against the build time rather than
-// against "now" is what makes this exact: keying off the age of the mtime gave a
-// window that shrank to nothing for a write late in a second.
 export function stampIsAmbiguous(
   mtimeMs: number,
   builtAt: number,
@@ -136,9 +89,6 @@ export function stampIsAmbiguous(
 }
 
 function tsconfigNeedsRebuild(snapshot: Snapshot, rootDir: string): boolean {
-  // Resolved first: the stored path came from the resolved root, so comparing a
-  // raw symlinked root found a different config every time and rebuilt the
-  // whole graph on every lint.
   const currentPath = findTsconfig(safeRealpath(rootDir) ?? rootDir);
   const previousPath = snapshot.configs[0]?.path;
   if (currentPath !== previousPath) {
@@ -150,10 +100,6 @@ function tsconfigNeedsRebuild(snapshot: Snapshot, rootDir: string): boolean {
   });
 }
 
-// Every tracked file, not only the one being linted. ESLint lints one file at a
-// time, so checking just that file left an edit to any other file invisible: the
-// report neither appeared nor - worse - went away once the user fixed the import
-// in the file that caused it. Deletions were never noticed at all.
 function trackedFilesChanged(snapshot: Snapshot): boolean {
   for (const [file, prev] of snapshot.stamps) {
     const stat = safeStat(file);
@@ -174,10 +120,6 @@ function trackedFilesChanged(snapshot: Snapshot): boolean {
   return false;
 }
 
-// Mirrors what walkDir would have collected, via the one statement of graph
-// membership in scope.ts. Anything walkDir skips must be skipped here too, or
-// linting one such file rebuilds the whole graph every time because its stamp is
-// never recorded.
 function isProductionGraphFile(
   currentFile: string,
   rootDir: string,
@@ -190,17 +132,6 @@ function isProductionGraphFile(
   return isInGraphScope(path.relative(realRoot, currentFile), ignoreGlobs);
 }
 
-// Recognises a second rule asking about the same parse. Bounded by
-// REVALIDATE_AFTER_MS because token identity proves "same SourceCode object",
-// not "same moment": Linter#verify accepts a SourceCode instance and passes its
-// identity straight through to context.sourceCode, so a host that retains one
-// and re-verifies it keeps the token alive indefinitely. Unbounded, that froze
-// the graph permanently - every later verify matched the token, so neither the
-// tsconfig check nor the tracked-file sweep ever ran again, and a report could
-// not be made to go away by editing any file other than the one being linted.
-// The bound costs nothing inside a real parse (two rules are microseconds apart)
-// and puts the worst case back on the same footing as every other staleness
-// window here.
 function isSameParse(
   pass: PassState,
   currentFile: string,
@@ -214,16 +145,6 @@ function isSameParse(
   );
 }
 
-/**
- * Whether the cached graph can be handed back as-is.
- *
- * Order matters. A second rule's call inside the very same parse cannot have
- * observed a tsconfig edit or a tracked-file change that the first rule's call
- * did not already validate, so `isSameParse` comes first and skips both sweeps
- * entirely - `tsconfigNeedsRebuild`'s realpath + findTsconfig walk + config
- * stats, and the once-per-pass stamp sweep with its own realpath - rather than
- * merely avoiding the pass-boundary bookkeeping.
- */
 function isFresh(
   entry: CacheEntry,
   currentFile: string,
@@ -239,10 +160,6 @@ function isFresh(
     return false;
   }
 
-  // Validate the tracked set once per pass: seeing a file again means a new pass
-  // began, and the elapsed-time bound covers passes that never revisit a file.
-  // Any repeat of currentFile that reaches here is a genuine new pass, because
-  // isSameParse already absorbed a second rule re-checking the same file.
   const now = Date.now();
   if (
     pass.visited.has(currentFile) ||
@@ -256,17 +173,12 @@ function isFresh(
   }
   pass.visited.add(currentFile);
 
-  // No stamp means the file was created since the build, so the graph does not
-  // know about it yet.
   if (snapshot.stamps.has(currentFile)) {
     return true;
   }
   return !isProductionGraphFile(currentFile, rootDir, ignoreGlobs);
 }
 
-// One step, because the pair is meaningless apart: a lastFile without its
-// lastToken (or vice versa) is a same-parse hit waiting to be claimed by the
-// wrong caller.
 function markVisit(
   pass: PassState,
   currentFile: string,
@@ -277,21 +189,6 @@ function markVisit(
     visitToken === undefined ? undefined : new WeakRef(visitToken);
 }
 
-/**
- * The graph for `rootDir`, built once per process and revalidated once per lint
- * pass.
- *
- * `visitToken` should be `context.sourceCode`: ESLint hands every rule the
- * identical object for one parse of a file and a new object for every subsequent
- * parse, so it is what lets a second rule asking about the same file skip
- * revalidation entirely rather than merely avoid tripping the pass-boundary
- * check (see runRules in ESLint's linter, which builds one shared rule-context
- * base per file and extends it per rule; verified this holds across ESLint 9 and
- * 10, under `--cache`, `lintText`, and a processor splitting one file into
- * several blocks). Omitting it - a direct call from a test, a single-rule setup
- * that only ever asks once per file - keeps the original, more conservative
- * behaviour, where every repeat of a file counts as a new pass.
- */
 export function getGraph(
   rootDir: string,
   ignoreGlobs: string[],
@@ -310,8 +207,6 @@ export function getGraph(
 
   const { graph, configPaths } = buildGraphWithConfigs(rootDir, ignoreGlobs);
   const stamps = stampFiles(graph.files);
-  // One clock read: the build and its first validation are the same event, and
-  // two Date.now() calls could straddle a millisecond boundary.
   const now = Date.now();
   const entry: CacheEntry = {
     snapshot: {

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -6,47 +6,17 @@ import { extractSpecifiers } from "./parse.js";
 import { createResolutionSettings, resolveSpecifier, type ResolutionSettings } from "./resolve.js";
 import { collectSourceFiles } from "./walk.js";
 
-/**
- * Readonly because six indexes are derived from a graph and memoised against
- * the graph object for its whole lifetime (see derived.ts): mutating `files` or
- * `importers` in place would silently desync every one of them. A changed tree
- * produces a NEW graph - which is also what drops the old indexes, since
- * nothing invalidates them.
- */
 export interface Graph {
   readonly importers: ReadonlyMap<string, readonly string[]>;
   readonly files: readonly string[];
 }
 
-// Exact graph membership, memoised and primed by the builder. It is not part of
-// Graph itself for the same reason none of the other indexes are: a graph is the
-// raw pair of tables, and everything derived from it lives in a weak table keyed
-// on that pair (see derived.ts).
 const graphFileSet = derivedFromGraph((graph) => new Set(graph.files));
 
-/**
- * Whether the graph contains this exact path.
- *
- * Exact on purpose: a caller asking "does the model know this module" is
- * checking a path it got from the graph or from `collectReExports`, and folding
- * would answer for a different file. Use `canonicalGraphPath` first when the
- * path came from a specifier instead.
- */
 export function graphHasFile(graph: Graph, filePath: string): boolean {
   return graphFileSet(graph).has(filePath);
 }
 
-// The two axes on which a resolved path can disagree with the graph's own
-// spelling while still naming the same file on disk:
-//
-// - Unicode normalization, always. `readdir` reports whatever form the
-//   filesystem stores, while a specifier carries whatever form the author's
-//   editor wrote, and `realpath` preserves it rather than converting. macOS
-//   happily opens either, so "Café/inner.ts" written NFD resolves to a real
-//   file whose graph key is NFC - different bytes, same file. This is not
-//   case-sensitivity-dependent, so it is folded on every platform.
-// - Case, only where the filesystem ignores it. Folding case on a
-//   case-sensitive volume would merge two genuinely distinct files.
 function foldGraphPath(filePath: string): string {
   const normalized = filePath.normalize("NFC");
   return ts.sys.useCaseSensitiveFileNames
@@ -54,57 +24,17 @@ function foldGraphPath(filePath: string): string {
     : normalized.toLowerCase();
 }
 
-// Graph files indexed by their folded key (see foldGraphPath), for recovering
-// the graph's own spelling of a path that points at the same file by a different
-// one. Built on demand rather than primed by buildGraphWithConfigs: the map that
-// function builds for edge recovery is keyed on lower case alone, which is a
-// different key from this one, so the two cannot be shared.
 const graphFilesByFoldedPath = derivedFromGraph(
   (graph) => new Map(graph.files.map((file) => [foldGraphPath(file), file])),
 );
 
-/**
- * The graph's own spelling of a resolved path, or the path unchanged when
- * nothing in the graph matches it.
- *
- * `resolveSpecifier` hands back a path built from the specifier's own text, and
- * `fs.realpathSync` (what `safeRealpath` uses) neither folds case on macOS - only
- * its `.native` variant does - nor normalizes Unicode on any platform. So a path
- * that resolved perfectly well can still differ byte-for-byte from the one the
- * walk recorded. Callers that key off a file's directory (gates) need the
- * recorded spelling or they miss real boundaries and invent fake ones.
- */
 export function canonicalGraphPath(graph: Graph, filePath: string): string {
-  // An exact member of graph.files is already in the graph's spelling, so
-  // folding it would be a rewrite rather than a recovery - the same precedence
-  // buildGraphWithConfigs applies to resolveSpecifier's result. Two files can
-  // share one folded key (differing only by case on a filesystem that ignores
-  // case, or only by normalization on one that does not) and the map keeps
-  // whichever came last, so without this guard one of them silently becomes the
-  // other: an internal `Foo/Index.ts` folds onto the door `Foo/index.ts` and its
-  // crossing vanishes, and the door itself can fold onto an internal file and be
-  // reported as reaching past itself.
   if (graphFileSet(graph).has(filePath)) {
     return filePath;
   }
   return graphFilesByFoldedPath(graph).get(foldGraphPath(filePath)) ?? filePath;
 }
 
-// Total, not a bare lookup: resolveSpecifier's settings parameter is optional
-// and silently falls back to a lenient default with no project `paths`, so a
-// caller that tolerated `undefined` here would resolve every aliased import
-// to nothing without anything looking broken. The only miss in practice is a
-// graph built from buildGraphWithConfigs' missing-root early return, which
-// has no files to resolve specifiers for anyway.
-//
-// Unprimed graphs get the same no-project settings: walking from cwd or `"."`
-// would pick up whatever tsconfig happens to be nearby (including this repo's
-// when tests run here) and silently attach paths a graph that was never built
-// never earned.
-//
-// The settings carry a TypeScript module resolution cache, so keeping them for
-// the graph's lifetime is the point rather than a bonus. When that lifetime ends
-// is entirely up to the graph cache's own revalidation (see graph-cache.ts).
 function noProjectResolutionSettings(): ResolutionSettings {
   const resolutionOptions: ts.CompilerOptions = {
     moduleResolution: ts.ModuleResolutionKind.Bundler,
@@ -140,9 +70,6 @@ export function buildGraphWithConfigs(
   const files = collectSourceFiles(resolvedRoot, ignoreGlobs);
 
   const fileSet = new Set(files);
-  // On a case-insensitive filesystem the compiler resolves "./Helper" against
-  // helper.ts but hands back the path as written, which matched nothing here and
-  // silently dropped the edge. Recover the real casing.
   const filesByLowerCase = ts.sys.useCaseSensitiveFileNames
     ? undefined
     : new Map(files.map((file) => [file.toLowerCase(), file]));
@@ -164,9 +91,6 @@ export function buildGraphWithConfigs(
       const target = fileSet.has(resolved)
         ? resolved
         : filesByLowerCase?.get(resolved.toLowerCase());
-      // A file importing itself says nothing about ownership, and the
-      // case-insensitive fallback would otherwise invent such an edge from a
-      // wrong-case self import.
       if (target === undefined || target === file) {
         continue;
       }
@@ -182,12 +106,6 @@ export function buildGraphWithConfigs(
 
   const graph: Graph = { importers, files };
   getGraphResolutionSettings.prime(graph, settings);
-  // Reuses the member set just built for edge recovery, which is the one index
-  // canonicalGraphPath needs that is known equal here for free. Its folded index
-  // is deliberately not primed from `filesByLowerCase`: that map is keyed on
-  // lower case alone, whereas the fold also normalizes Unicode and skips the
-  // lower-casing entirely on a case-sensitive filesystem, so they are different
-  // keys and sharing them would reintroduce the mismatch this exists to close.
   graphFileSet.prime(graph, fileSet);
   return { graph, configPaths: settings.configPaths };
 }

--- a/src/lib/owners.ts
+++ b/src/lib/owners.ts
@@ -20,9 +20,7 @@ export interface OwnershipContext {
 }
 
 export interface ReExports {
-  /** Sibling modules in the same directory, one entry per module. */
   local: string[];
-  /** Every re-exported module, including modules from elsewhere. */
   total: number;
 }
 
@@ -38,23 +36,8 @@ export function collectReExports(
     return { local: [], total: 0 };
   }
   const sourceFile = parseSourceFile(indexFile, content);
-  // Resolving without these silently drops every aliased re-export: the
-  // fallback inside resolveSpecifier carries no project `paths` and no
-  // baseUrl, so "@/Foo/Bar" named no sibling and one tsconfig alias
-  // reclassified the barrel - and with it every finding downstream of
-  // getColocationConsumers.
   const settings = getGraphResolutionSettings(graph);
-  // Keyed by module, not by declaration: the idiomatic value + type split
-  // ("export { x } from './X'; export type { T } from './X';") re-exports one
-  // sibling and must not look like a two-module namespace barrel.
   const local = new Set<string>();
-  // Keyed by resolved module where there is one, and by specifier text only
-  // where there is not, so a re-export that does not resolve (a bare package, a
-  // types-only module) still marks this index as an aggregator while two
-  // spellings of one module count once. Keying on the text alone made "./Bar"
-  // plus "./Bar.js" - or, on a case-insensitive disk, "./Bar" plus "./bar" - an
-  // aggregator, which suppressed mismatchedEntry just as thoroughly as the
-  // double-counted sibling that came with it.
   const modules = new Set<string>();
 
   const visit = (node: ts.Node): void => {
@@ -65,23 +48,12 @@ export function collectReExports(
     ) {
       const specifier = node.moduleSpecifier.text;
       const resolved = resolveSpecifier(specifier, dir, settings);
-      // resolveSpecifier builds its answer from the specifier's own text and
-      // realpath folds neither case nor Unicode normalization, so a target that
-      // resolved perfectly well can still be spelled differently from the graph
-      // key for the same file. Only the target needs recovering: realDir and
-      // realIndex come from a path the walk itself recorded.
       const target =
         resolved === undefined
           ? undefined
           : canonicalGraphPath(graph, resolved);
-      // An index re-exporting itself ("export * from './index'") names no
-      // sibling at all.
       if (target === undefined || target !== realIndex) {
         modules.add(target ?? specifier);
-        // Asked of the resolved file rather than of the specifier's spelling:
-        // a relative-specifier gate here said the same thing for "./Bar" and
-        // the wrong thing for an aliased sibling, which stayed uncounted and
-        // so unbarrelled.
         if (target !== undefined && path.dirname(target) === realDir) {
           local.add(target);
         }
@@ -115,10 +87,6 @@ function isOwnerEntryFile(file: string, dir: string, graph: Graph): boolean {
   if (base !== "index") {
     return false;
   }
-  // An index makes its directory a module only when the directory is imported
-  // through it. A barrel over loose helpers is not a module boundary: counting
-  // it as one made a shared helper directory an "owner", which both flagged the
-  // files inside it and silenced a standalone owner's private helper.
   return (graph.importers.get(file) ?? []).some(
     (importer) => path.dirname(importer) !== dir,
   );
@@ -169,7 +137,6 @@ function buildImports(graph: Graph): Map<string, string[]> {
   return imports;
 }
 
-// Tarjan, iterative so a deep import chain cannot blow the stack.
 function stronglyConnectedIds(
   nodes: readonly string[],
   edgesOf: (node: string) => string[],
@@ -254,11 +221,6 @@ function getRoots(graph: Graph): Set<string> {
     graph.files,
     (file) => imports.get(file) ?? [],
   );
-  // Entry points are whole components, not individual files. Inside a cycle
-  // nothing is importer-free, so asking for zero importers leaves a cyclic
-  // entry with no roots at all and strips the shell exemption from the whole
-  // project; asking each file individually would promote the inner half of a
-  // cycle that something outside imports.
   const importedFromOutside = new Set<number>();
   for (const file of graph.files) {
     const component = componentIds.get(file);
@@ -280,11 +242,6 @@ function getRoots(graph: Graph): Set<string> {
   return roots;
 }
 
-// Entry points plus what they import directly. Deliberately not configurable and
-// deliberately not transitive: a longer bootstrap chain is expressed by declaring
-// the directories it reaches as layers, which states something true about those
-// modules. Exempting the shell's imports outright would also hide a shell that
-// reaches past a feature's entry into its internals - a real finding.
 export const getShells = derivedFromGraph((graph) => {
   const roots = getRoots(graph);
   const shells = new Set(roots);
@@ -329,9 +286,6 @@ function collectLayerDirs(
     }
 
     const fullPath = path.join(dir, entry.name);
-    // Matched against both spellings: `ignore` globs are relative to `root`
-    // while these were relative to the working directory, so with root: "src"
-    // the natural glob silently matched nothing.
     const candidates = [
       path.relative(cwd, fullPath).split(path.sep).join("/"),
       path.relative(rootDir, fullPath).split(path.sep).join("/"),
@@ -363,15 +317,6 @@ export function collectLayerDirectories(
   return dirs;
 }
 
-// Memoised against the graph rather than for the life of the process: a layer
-// directory created mid-session used to stay invisible until ESLint restarted,
-// which meant a permanent false privateOutsideOwner on every module inside it.
-// A new directory rebuilds the graph, which drops this entry with it.
-//
-// Two-level, unlike every other index here: the graph does not determine the
-// answer on its own, so the inner map keys the parts that vary per call. Passing
-// them to derivedFromGraph as extra arguments would serve one graph's first
-// answer to every later cwd and glob set.
 const layerDirsByGraph = derivedFromGraph(() => new Map<string, string[]>());
 
 export function resolveLayerDirectories(
@@ -416,8 +361,6 @@ export function isLayerPublicModule(
 
   const folderName = path.basename(parent);
   const fileBase = path.basename(filePath, path.extname(filePath));
-  // "index" is an entry everywhere else in the plugin, so a layer folder using
-  // one was told to move somewhere it cannot go.
   return fileBase === folderName || fileBase === "index";
 }
 
@@ -538,10 +481,6 @@ export function getSharedColocationIssue(
   const ownerDirs = [...new Set([...owners.values()].map(ownerDir))];
   const lca = longestCommonAncestor(ownerDirs);
 
-  // Only a folder owner has a folder to be inside of; a standalone owner's parent
-  // directory belongs to nobody. Every folder owner above the subject counts, not
-  // just the innermost one, so a folder entry buried in an unrelated tree is
-  // still caught by the tree it is buried in.
   const consumerFolderDirs = [...owners.values()]
     .filter((owner) => owner.kind === "folder")
     .map((owner) => owner.path);
@@ -554,14 +493,9 @@ export function getSharedColocationIssue(
     if (!isInsideDir(filePath, dir)) {
       return false;
     }
-    // A folder at or above the common ancestor holds every consumer, so being
-    // inside it is not "tucked inside one owner".
     if (!isInsideDir(dir, lca)) {
       return false;
     }
-    // A folder's own entry is never misplaced within its own folder - there is
-    // nowhere else for it to go. If the folder itself sits in the wrong place,
-    // the folders above it say so, and they are still in this list.
     return !isOwnerEntryFile(filePath, dir, ctx.graph);
   });
 

--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -26,22 +26,18 @@ export function parseSourceFile(
     fileName,
     content,
     ts.ScriptTarget.Latest,
-    /*setParentNodes*/ false,
+    false,
     scriptKindFromFileName(fileName),
   );
 }
 
 function stringLiteralText(node: ts.Node | undefined): string | undefined {
-  // No-substitution templates are as static as quotes. isStringLiteral
-  // rejects them, so one character dropped the graph edge.
   if (node !== undefined && ts.isStringLiteralLike(node)) {
     return node.text;
   }
   return undefined;
 }
 
-// The specifier this node imports through, or undefined when it imports
-// nothing. `requireIsCjs` decides only whether a bare `require(...)` counts.
 function importedSpecifier(
   node: ts.Node,
   requireIsCjs: boolean,
@@ -64,8 +60,6 @@ function importedSpecifier(
   ) {
     return stringLiteralText(node.arguments[0]);
   }
-  // ImportTypeNode is not a CallExpression. Type-position import("./x").T
-  // and typeof import("./x") used to leave the target with no importer.
   if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
     return stringLiteralText(node.argument.literal);
   }
@@ -79,9 +73,6 @@ export function extractSpecifiers(
   const sourceFile = parseSourceFile(fileName, content);
   const specifiers: string[] = [];
 
-  // Scope-aware: a `require` bound in an unrelated nested scope used to disable
-  // every require() edge in the file, while a parameter named require must still
-  // shadow it within that function.
   const visit = (node: ts.Node, shadowed: boolean): void => {
     const requireIsCjs = !(shadowed || scopeBindsRequire(node));
     const specifier = importedSpecifier(node, requireIsCjs);

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,27 +1,10 @@
 import path from "node:path";
 
-/**
- * Whether `filePath` sits strictly inside `dir`.
- *
- * One home for a predicate that previously existed in three copies - in
- * `gates.ts`, `owners.ts`, and as `isWithinRoot` in `graph.ts` - each carrying
- * the same defect: appending a separator to a `dir` that already ends in one
- * builds `"//"`, which matches nothing, so a file plainly inside the directory
- * looked outside it. That is reachable rather than theoretical, because
- * `resolveRootDir` returns an absolute `root` verbatim and so `root: "/"`
- * survives all the way down here. Fixing one copy left the other two wrong; the
- * point of this module is that there is nowhere left for them to disagree.
- *
- * Lives on its own rather than in `graph.ts` so that `gates.ts` can use it
- * without the access model depending on the graph or the ownership model, which
- * is what the duplication was originally protecting.
- */
 export function isInsideDir(filePath: string, dir: string): boolean {
   const prefix = dir.endsWith(path.sep) ? dir : dir + path.sep;
   return filePath.startsWith(prefix);
 }
 
-/** `isInsideDir`, but a directory also counts as being at itself. */
 export function isAtOrInsideDir(filePath: string, dir: string): boolean {
   return filePath === dir || isInsideDir(filePath, dir);
 }

--- a/src/lib/require-binding.ts
+++ b/src/lib/require-binding.ts
@@ -2,23 +2,6 @@ import type { Scope, SourceCode } from "eslint";
 import type * as ESTree from "estree";
 import ts from "typescript";
 
-/**
- * One policy, two ASTs.
- *
- * `require` is only an import edge when the name really is Node's CJS require: a
- * local binding shadows it, and EVERY def of that binding must be
- * `createRequire(...)` for the name to still be the real thing. There are
- * necessarily two implementations of that one rule, because the two callers hold
- * incompatible ASTs and neither can borrow the other's: `parse.ts` answers it
- * over a bare TypeScript `SourceFile` (no binder, no program, no scope manager)
- * for every file in the tree, while `rules/entry.ts` answers it over ESLint's
- * scope manager for the one file being linted, and must report on a positioned
- * node. Keeping both in this one file is what stops them drifting apart
- * silently. They already have: see docs/agents/known-issues.md for the binders the
- * TypeScript-side walk cannot see.
- */
-// Both spellings count as the constructor: `createRequire(...)` and
-// `mod.createRequire(...)`.
 const CREATE_REQUIRE = "createRequire";
 
 const REQUIRE = "require";
@@ -60,11 +43,6 @@ function bindsName(name: ts.BindingName, target: string): boolean {
   );
 }
 
-/**
- * Whether this TypeScript scope itself binds `require`, shadowing the CJS one.
- * Answered from a bare `ts.SourceFile`, so only the binders visible in the
- * syntax tree count.
- */
 export function scopeBindsRequire(node: ts.Node): boolean {
   if (ts.isFunctionLike(node)) {
     if (node.parameters.some((p) => bindsName(p.name, REQUIRE))) {
@@ -87,8 +65,6 @@ export function scopeBindsRequire(node: ts.Node): boolean {
         if (!bindsName(declaration.name, REQUIRE)) {
           continue;
         }
-        // `const require = createRequire(import.meta.url)` IS the real require,
-        // so its calls are genuine edges.
         if (tsIsCreateRequireCall(declaration.initializer)) {
           continue;
         }
@@ -106,11 +82,6 @@ export function scopeBindsRequire(node: ts.Node): boolean {
   return false;
 }
 
-/**
- * The same question over ESLint's scope chain, which resolves it properly: a
- * `require` bound in an enclosing scope is not the CJS one, so it is not an edge
- * - unless it was bound by createRequire, which is.
- */
 export function requireIsShadowed(
   sourceCode: SourceCode,
   node: ESTree.Node,
@@ -118,21 +89,7 @@ export function requireIsShadowed(
   let scope: Scope.Scope | null = sourceCode.getScope(node);
   while (scope !== null) {
     const variable = scope.variables.find((entry) => entry.name === REQUIRE);
-    // An ambient/global `require` (Node's CJS globals, a `.cjs` file's
-    // default sourceType, `globals: globals.node`) has no defs at all - it
-    // is not a local binding, so it must not be treated as shadowing the
-    // CJS one. Only a variable with an actual definition here (parameter,
-    // `const`, `function require() {}`, ...) can shadow it.
     if (variable !== undefined && variable.defs.length > 0) {
-      // Every def has to be a createRequire binding for the name to still be
-      // the real require. `defs.some` was order-blind: with `var require =
-      // createRequire(url)` followed by `var require = 1`, the call loads
-      // nothing at all, yet a some() check still called it genuine and
-      // reported a crossing that cannot happen. Requiring all of them trades
-      // that false positive for a false negative in the mirror case (plain
-      // first, createRequire second) - the right way round for a lint rule,
-      // and just as rare, since both need `require` declared twice in one
-      // scope.
       return !variable.defs.every((def) => {
         const declarator = def.node as {
           type: string;

--- a/src/lib/resolve.ts
+++ b/src/lib/resolve.ts
@@ -9,9 +9,6 @@ export interface ResolutionSettings {
   configPaths: string[];
 }
 
-// One lenient policy for every specifier, whatever the project configures for
-// tsc: bundler-style resolution accepts extensionless imports and maps
-// "./x.js" onto x.ts, which is how these projects are actually built.
 const RESOLUTION_OVERRIDES: ts.CompilerOptions = {
   moduleResolution: ts.ModuleResolutionKind.Bundler,
   allowJs: true,
@@ -30,8 +27,6 @@ function loadCompilerOptions(rootDir: string): {
     return { options: {}, configPaths: [] };
   }
 
-  // getParsedCommandLineOfConfigFile (rather than readConfigFile) is what
-  // follows "extends", so paths declared in a base config are honoured.
   const parsed = ts.getParsedCommandLineOfConfigFile(
     configPath,
     {},
@@ -112,13 +107,6 @@ function probeResolvedPath(base: string): string | undefined {
   return undefined;
 }
 
-// The compiler will not try .cts/.cjs for an extensionless specifier, and for a
-// non-relative one there is no path left to probe once it gives up - so the
-// mapping is expanded here, longest prefix first, exactly as tsc orders it.
-// tsc picks exactly one pattern - an exact key first, otherwise the longest
-// matching prefix - and if that pattern's targets do not exist the specifier is
-// simply unresolved. Trying every matching pattern invented edges the compiler
-// refuses.
 function bestPathPattern(
   specifier: string,
   paths: Record<string, string[]>,
@@ -179,12 +167,6 @@ function aliasCandidates(
       ? ""
       : specifier.slice(star, specifier.length - (pattern.length - star - 1));
 
-  // tsc reports a diagnostic for a malformed `paths` entry but still hands the
-  // raw value straight back in options.paths, so a one-bracket typo
-  // (`"@/*": "src/*"` instead of `["src/*"]`) or a non-string target arrives
-  // here exactly as written. Taken on trust, that threw a TypeError out of the
-  // rule and killed the entire lint run with no results at all - the one thing
-  // the filesystem handling everywhere else is careful never to do.
   const targets = paths[pattern];
   if (!Array.isArray(targets)) {
     return [];
@@ -231,8 +213,6 @@ export function resolveSpecifier(
     }
   }
 
-  // Extensions the compiler will not resolve on its own (.cts, .cjs) still
-  // resolve here, for relative and aliased specifiers alike.
   if (specifier.startsWith(".")) {
     return probeResolvedPath(path.resolve(fromDir, specifier));
   }

--- a/src/lib/root.ts
+++ b/src/lib/root.ts
@@ -1,16 +1,6 @@
 import path from "node:path";
 import { safeStat } from "./fs-safe.js";
 
-// A relative root is resolved against the working directory, but ESLint may be
-// invoked from anywhere - a subdirectory, via lint-staged, from a monorepo script.
-// Resolving "src" against cwd alone meant the directory was simply not found from
-// a subdirectory, and a missing root reports nothing, so the rules go quiet
-// instead of complaining. Walk up until the configured root exists.
-//
-// The returned path is a candidate, not a guarantee: when nothing matched during
-// the walk, resolveRootDir falls back to the plain cwd-relative resolution, which
-// may not exist on disk. Callers must degrade to no findings rather than assume
-// the result is real.
 function isProjectBoundary(dir: string): boolean {
   return (
     safeStat(path.join(dir, "package.json")) !== undefined ||
@@ -29,10 +19,6 @@ export function resolveRootDir(rootOption: string, cwd: string): string {
     if (safeStat(candidate)?.isDirectory() === true) {
       return candidate;
     }
-    // Stop at the project it belongs to. Unbounded, the walk would happily
-    // resolve root: "src" to a checkout's parent directory that happens to be
-    // called src, taking unrelated projects into the graph and making the
-    // findings depend on where the repository sits on disk.
     if (isProjectBoundary(dir)) {
       break;
     }

--- a/src/lib/scope.ts
+++ b/src/lib/scope.ts
@@ -30,8 +30,6 @@ export function isSourceFile(p: string): boolean {
   return SOURCE_EXTS.some((ext) => p.endsWith(ext));
 }
 
-// Takes a path relative to the root: given an absolute one, a `__tests__`
-// directory anywhere ABOVE the project would have disabled the rule entirely.
 export function isTestFile(relPath: string): boolean {
   return (
     relPath.split(path.sep).includes("__tests__") ||
@@ -48,17 +46,11 @@ export function isOutsideRoot(relPath: string): boolean {
   return (
     relPath === "" ||
     relPath === ".." ||
-    // Not startsWith("..") - a directory named "..data" (Kubernetes mounts one)
-    // is inside the root.
     relPath.startsWith(".." + path.sep) ||
     path.isAbsolute(relPath)
   );
 }
 
-// A file is excluded when it, or any directory above it, is skipped or ignored -
-// which is what walkDir does as it descends. Checking only the file's own path
-// let an ignore glob naming a directory ("gen" rather than "gen/**") pass, and
-// never consulted SKIP_DIRS at all.
 export function isExcludedPath(relPath: string, ignoreGlobs: string[]): boolean {
   const segments = relPath.split(path.sep);
   for (let i = 1; i <= segments.length; i += 1) {
@@ -72,17 +64,6 @@ export function isExcludedPath(relPath: string, ignoreGlobs: string[]): boolean 
   return false;
 }
 
-/**
- * Whether a path relative to the root names a file the walk would have
- * collected. The one statement of graph membership: the rules ask it whether the
- * linted file is a subject at all and whether a resolved target is in the model,
- * and the graph cache asks it whether an unstamped file is one the walk should
- * have picked up.
- *
- * Four inline copies of this disjunction is exactly how `isInsideDir` came to
- * exist in three copies sharing one defect - fixing one left the others wrong.
- * Do not reintroduce a local copy.
- */
 export function isInGraphScope(
   relPath: string,
   ignoreGlobs: string[],

--- a/src/lib/subject.ts
+++ b/src/lib/subject.ts
@@ -6,46 +6,14 @@ import type { Graph } from "./graph.js";
 import { resolveRootDir } from "./root.js";
 import { isInGraphScope, isSourceFile } from "./scope.js";
 
-/**
- * The file a rule has been asked about, once it is known to be one the model can
- * talk about at all.
- *
- * Both rules opened with the same preamble - default the root, resolve it
- * against a cwd that may be anywhere, realpath it and the linted file, tolerate
- * either being absent, then reject the file for being outside the root, a test,
- * or excluded. Two copies of that is how `isInsideDir` came to exist in three
- * copies sharing one defect; do not reintroduce a local one.
- */
 export interface Subject {
-  /**
-   * The configured root, resolved but deliberately NOT realpathed: it is half
-   * the graph cache key, so realpathing it here would give a symlinked root a
-   * second cache entry and change when the graph is rebuilt.
-   */
   readonly rootDir: string;
-  /** The same root, realpathed - what every path comparison uses. */
   readonly realRootDir: string;
-  /** The linted file, realpathed. */
   readonly file: string;
-  /**
-   * The same file under the path ESLint handed over, NOT realpathed. Every path
-   * comparison uses `file`; this exists because ownership's `mismatchedEntry`
-   * decision asks "is this an index?" of the linted path and always has, and a
-   * symlink named `index.ts` pointing at a differently-named module answers the
-   * two questions differently. Do not reach for it for anything else.
-   */
   readonly lintedPath: string;
   readonly ignore: string[];
-  /**
-   * Built on first use and memoised for this file, so a file that asks nothing
-   * never pays for the graph and a file that asks repeatedly pays once. Supplies
-   * `context.sourceCode` as `getGraph`'s visit token, which is what lets both
-   * rules share one revalidation of the same parse.
-   */
   graph(): Graph;
-  /** Whether a resolved path is a file the model can talk about. */
   covers(filePath: string): boolean;
-  /** Posix-relative to the root, for report message data. */
   display(filePath: string): string;
 }
 
@@ -54,12 +22,6 @@ interface SubjectOptions {
   ignore?: string[];
 }
 
-/**
- * `undefined` when there is nothing to say about this file: a root that is not
- * on disk, a linted path that is not a real file (processors,
- * `--stdin-filename`, a file deleted mid-run), or a file outside the model.
- * Tolerant rather than throwing, since none of those is the user's mistake.
- */
 export function resolveSubject(context: Rule.RuleContext): Subject | undefined {
   const options = (context.options[0] ?? {}) as SubjectOptions;
   const ignore = options.ignore ?? [];
@@ -75,10 +37,6 @@ export function resolveSubject(context: Rule.RuleContext): Subject | undefined {
     return undefined;
   }
 
-  // Deliberate asymmetry: resolved targets are extension-tested by `covers`,
-  // but the linted file is only scope-tested here - the extension check already
-  // happened on the path ESLint handed over, so a `.ts` symlink pointing at a
-  // `.txt` file is still a subject.
   if (!isInGraphScope(path.relative(realRootDir, file), ignore)) {
     return undefined;
   }

--- a/src/lib/walk.ts
+++ b/src/lib/walk.ts
@@ -19,10 +19,6 @@ function walkDir(
   behindLink: boolean,
 ): void {
   const realDir = safeRealpath(dir);
-  // Guarded per branch rather than globally: two sibling links to one real
-  // directory are both legitimate, and a global set let whichever path was
-  // walked first decide the other's fate - so an ignore glob aimed at a link
-  // erased the real directory too.
   if (realDir === undefined || ancestorRealDirs.has(realDir)) {
     return;
   }
@@ -32,9 +28,6 @@ function walkDir(
     const fullPath = path.join(dir, entry.name);
     const relPath = path.relative(rootDir, fullPath);
 
-    // readdir reports a symlink as neither file nor directory, so entries were
-    // dropped here while the resolver followed them happily - a module behind a
-    // linked directory was invisible as a consumer. Stat follows the link.
     const stat = entry.isSymbolicLink() ? safeStat(fullPath) : undefined;
     const isDirectory = entry.isSymbolicLink()
       ? (stat?.isDirectory() ?? false)
@@ -50,20 +43,11 @@ function walkDir(
       continue;
     }
 
-    // Only links (and anything below one) need resolving; on a tree with no
-    // symlinks fullPath is already canonical, because the walk started from the
-    // resolved root.
     const isLink = entry.isSymbolicLink();
     const realPath = isLink || behindLink ? safeRealpath(fullPath) : fullPath;
     if (realPath === undefined) {
       continue;
     }
-    // Links are checked under the path they really point at as well. Anything
-    // resolving outside the root stays out of the graph: such files cannot be
-    // reported (they are outside root) yet would still act as importers and as
-    // owners, which turned a linked-in directory into a phantom second owner and
-    // a symlinked entry file into a directory that no longer had an entry.
-    // Ignoring a directory also cannot be undone by reaching it through a link.
     if (realPath !== fullPath) {
       if (!isAtOrInsideDir(realPath, rootDir)) {
         continue;
@@ -74,10 +58,6 @@ function walkDir(
     }
 
     if (isDirectory) {
-      // Sibling links to one real directory are both legitimate, but nesting
-      // them makes the walk exponential (2^depth), so each real directory is
-      // entered through a link at most once. Directories reached without a link
-      // are always walked.
       if (isLink) {
         if (linkedRealDirs.has(realPath)) {
           continue;
@@ -97,13 +77,11 @@ function walkDir(
     }
 
     if (isSourceFile(fullPath) && !isTestFile(relPath)) {
-      // A Set because following symlinks can reach the same real file twice.
       files.add(realPath);
     }
   }
 }
 
-/** Every source file under a resolved root, sorted, in the walk's own spelling. */
 export function collectSourceFiles(
   resolvedRoot: string,
   ignoreGlobs: string[],

--- a/src/rules/entry.ts
+++ b/src/rules/entry.ts
@@ -7,17 +7,6 @@ import { requireIsShadowed } from "../lib/require-binding.js";
 import { resolveSpecifier } from "../lib/resolve.js";
 import { resolveSubject, type Subject } from "../lib/subject.js";
 
-/**
- * The specifier this node imports through, or undefined when it is not
- * statically known.
- *
- * A no-substitution template literal is every bit as static as a quoted string -
- * import(`./x`) loads exactly what import("./x") loads - so it is accepted here.
- * Left out, backticks were a one-character way to launder every crossing in a
- * file past a rule whose whole purpose is a ratchet. One with substitutions is
- * not statically known and stays out, as does anything else non-literal
- * (concatenation, `as string`, identifiers).
- */
 function staticSpecifier(source: ESTree.Node): string | undefined {
   if (source.type === "Literal") {
     return typeof source.value === "string" ? source.value : undefined;
@@ -36,23 +25,6 @@ interface Crossing extends CrossedGate {
   target: string;
 }
 
-/**
- * The gate this specifier reaches past, or undefined when the import is legal.
- *
- * Both the target and the importer go through `canonicalGraphPath`, because
- * fs.realpathSync does not fold case. On the importer side a lower-cased linted
- * path left `isInsideDir` comparing against the gate's real key: it missed, and
- * the file was told to reach into the very directory it lives in - a report whose
- * only fix is to import its own door, i.e. a cycle. On the target side a resolved
- * path carries the specifier's casing, so "./Feature/FEATURE" misses `isEntryFile`
- * and reports a door the author already used, while "./feature/helper" misses the
- * gate key and reports nothing at all.
- *
- * `subject.covers` is also what keeps declaration files out: the walk skips them
- * and they can never be gates, but `resolveSpecifier`'s own probe still finds
- * `types.d.ts` for a "./types.d" specifier - which reported a crossing and named
- * a door that will never re-export the type.
- */
 function crossedGate(
   specifier: string,
   subject: Subject,
@@ -79,20 +51,6 @@ function crossedGate(
   return crossed === undefined ? undefined : { ...crossed, target };
 }
 
-// Neither of these is an ESTree node, so neither is in the parser's published
-// types. Extra visitor keys go through RuleListener's index signature, whose
-// node-shaped member is `(node: Node) => void`, so the parameter must accept
-// every ESTree node: required fields on a TS-only shape fail that (ESLint 10
-// used to type the extra-key parameter as `never`, which hid the constraint).
-// Optional fields on the shape actually read beat `unknown` plus a cast
-// inside the visitor, which hides the shape in the body.
-//
-// TSImportType carries the specifier in two places because the property moved:
-// `source` exists only from @typescript-eslint/parser 8.48, and before that the
-// specifier sits on `argument`, a TSLiteralType wrapping the same Literal. This
-// plugin pins no parser version (eslint is its only peer dependency), so reading
-// `source` alone left the visitor silently inert - check would just receive
-// undefined and return - on every 8.x below 8.48 that a user is free to install.
 interface TypeImportNode {
   source?: ESTree.Node;
   argument?: { literal?: ESTree.Node };
@@ -155,23 +113,9 @@ const rule: Rule.RuleModule = {
 
     return {
       ImportDeclaration: (node) => check(node.source),
-      // No barrel exemption here, unlike ownership's namespace-barrel handling:
-      // that exemption is about where a file belongs, not about whether reaching
-      // through it is legal. A barrel that re-exports a private file under a
-      // public name launders the violation - every downstream consumer of the
-      // barrel then looks innocent - so `export ... from` is checked exactly like
-      // an import. (ownership's predicate is sibling-scoped, so it would not even
-      // recognise a cross-directory barrel like this one.)
       ExportNamedDeclaration: (node) => check(node.source),
       ExportAllDeclaration: (node) => check(node.source),
       ImportExpression: (node) => check(node.source),
-      // `import("./x").T` and `typeof import("./x")` are TSImportType, not
-      // ImportExpression. Without this visitor the rule's answer depended on
-      // which of two equivalent type-import spellings the author picked:
-      // `import type { T } from "./x"` was gated and the inline form - what
-      // generated code and files avoiding top-level imports emit - was not,
-      // contradicting the "type-only imports treated like value imports"
-      // invariant.
       TSImportType: (node: TypeImportNode) =>
         check(node.source ?? node.argument?.literal),
       TSImportEqualsDeclaration: (node: ImportEqualsNode) => {
@@ -183,9 +127,6 @@ const rule: Rule.RuleModule = {
         if (
           node.callee.type !== "Identifier" ||
           node.callee.name !== "require" ||
-          // parse.ts takes arguments[0] at any arity, so require("./x", opts) is
-          // still an edge there; narrowed to exactly one argument here
-          // deliberately, since a real CJS require never takes a second one.
           node.arguments.length !== 1 ||
           requireIsShadowed(context.sourceCode, node)
         ) {

--- a/src/rules/ownership.ts
+++ b/src/rules/ownership.ts
@@ -2,8 +2,6 @@ import type { Rule } from "eslint";
 import { ownershipFindings } from "../lib/findings.js";
 import { resolveSubject } from "../lib/subject.js";
 
-// `root` and `ignore` are options here too, but resolveSubject is what reads
-// them - see the schema below, which is still the whole contract.
 interface RuleOptions {
   layers?: string[];
 }
@@ -45,16 +43,11 @@ const rule: Rule.RuleModule = {
 
     return {
       Program(node) {
-        // Resolved here rather than in create() for the same reason it always
-        // was: a configured root that does not exist, or a linted path that is
-        // not on disk (processors, --stdin-filename, a file deleted mid-run),
-        // means "nothing to say" rather than a crash.
         const subject = resolveSubject(context);
         if (subject === undefined) {
           return;
         }
 
-        // Report on the first statement so eslint-disable comments still apply under ESLint 10.
         const reportNode = node.body[0] ?? node;
         for (const messageId of ownershipFindings(
           subject,

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -106,24 +106,6 @@ describe("graph invalidation within one process", () => {
     expect(await lint(dir, ["src"], options)).toEqual([]);
   });
 
-  // ownership and entry both call getGraph for the same file within one lint
-  // pass. getGraph's pass-boundary check used to key only on the linted file
-  // path, so this second call looked exactly like a new pass landing on the
-  // same file and re-validated every tracked file by stat'ing it - once per
-  // linted file, per lint pass, an O(files^2) statSync cost that only showed
-  // up with both rules on. Every file has an import statement so entry's lazy
-  // getGraph call (made as soon as there is a specifier to check, whether or
-  // not it resolves) fires for each file - an import-free fixture would
-  // exercise only ownership's Program-level call and miss the bug entirely.
-  // The imported specifier does not resolve to anything in the fixture, so it
-  // creates no graph edge and triggers no ownership finding, keeping this
-  // test focused on getGraph call counting rather than ownership's placement
-  // rules. Asserted as a growth-rate comparison rather than a fixed
-  // threshold: a handful of unrelated extra stats anywhere in the walk would
-  // make a tight fixed bound flaky, but linear-in-files growth (this fix) and
-  // quadratic growth (the regression) are far enough apart that doubling the
-  // file count and checking the call count did not also roughly double keeps
-  // the test meaningful without pinning an exact figure.
   async function countStatsForFileCount(fileCount: number): Promise<number> {
     const files: Record<string, string> = {};
     for (let i = 0; i < fileCount; i += 1) {
@@ -150,27 +132,9 @@ describe("graph invalidation within one process", () => {
     const small = await countStatsForFileCount(20);
     const large = await countStatsForFileCount(40);
 
-    // Linear growth roughly doubles the call count when the file count
-    // doubles; the O(files^2) regression roughly quadruples it. The bound
-    // sits well above the former and well below the latter.
     expect(large).toBeLessThan(small * 2.5);
   });
 
-  // The fix for the above (a visitToken carried on the cache entry) must not
-  // regress the case it looks structurally identical to: a genuinely new pass
-  // that happens to start on the very file the previous pass ended on -
-  // exactly what a watch-mode re-lint of a single open file does. Each
-  // separate lintFiles() call gets its own ESLint SourceCode object even for
-  // an unchanged file, so the token differs across passes and this still
-  // revalidates.
-  //
-  // Both this test and the one above depend on their lintFiles() calls
-  // landing within REVALIDATE_AFTER_MS (100ms) of each other - the case they
-  // exercise (same file, different token) only fails the "same visit" check
-  // on the token; if the elapsed-time bound also tripped, revalidation would
-  // still happen, just for the wrong reason. On a sufficiently slow machine
-  // this test would still pass, but via the timer rather than the token it
-  // is meant to prove, losing its specificity.
   it("still revalidates when a new pass starts on the same single file the previous pass ended on", async () => {
     const dir = project(APP);
     const options = { root: "src" };
@@ -194,15 +158,6 @@ describe("graph invalidation within one process", () => {
     ]);
   });
 
-  // Token identity proves "same SourceCode object", not "same moment". A host
-  // may hold one SourceCode and verify it repeatedly - Linter#verify accepts a
-  // SourceCode instance and hands its identity straight through to
-  // context.sourceCode - and an unbounded short-circuit turned that into a
-  // permanently frozen graph: every later verify matched the token, so neither
-  // the tsconfig check nor the tracked-file sweep ever ran again and the report
-  // could not be cleared by editing any file other than the linted one. Uses
-  // Linter rather than the ESLint class because only Linter lets a caller supply
-  // the SourceCode and thus pin the token across passes.
   it("revalidates when one retained SourceCode is verified again after an edit", async () => {
     const dir = project({
       ...APP,
@@ -229,10 +184,6 @@ describe("graph invalidation within one process", () => {
 
     const retained = linter.getSourceCode();
     write(dir, { "src/pages/MyPage/MyPage.ts": "export const p = 1;\n" });
-    // Past REVALIDATE_AFTER_MS, so a correctly bounded short-circuit must let
-    // the tracked-file sweep run even though file and token both still match.
-    // Sleeps against the real constant rather than a copy of its value, so
-    // raising it cannot turn this into a mystery failure here.
     await new Promise((resolve) =>
       setTimeout(resolve, REVALIDATE_AFTER_MS + 50),
     );

--- a/tests/entry.test.ts
+++ b/tests/entry.test.ts
@@ -13,9 +13,6 @@ import {
 } from "./helpers/lint-fixture.js";
 
 describe("entry rule", () => {
-  // src/app.ts is an entry point: nothing imports it, so the ownership model
-  // would treat it as shell and exempt what it imports. This rule must not -
-  // a shell burrowing into a feature's internals is the finding worth having.
   it("reports an import that reaches past a module's entry", async () => {
     const messages = await lintEntryFixture("entry-reaches-past", {
       root: "src",
@@ -38,9 +35,6 @@ describe("entry rule", () => {
     expect(messages).toEqual([]);
   });
 
-  // The schema itself is asserted directly below; this exercises the
-  // behaviour that schema enables - ESLint actually rejecting an unknown
-  // option - the way ownership.test.ts does for the ownership rule.
   it("rejects unknown options", async () => {
     await expect(
       lintEntryFixture("entry-through-door-ok", { roots: "src" }),
@@ -62,8 +56,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // Rewriting a specifier produces code that does not compile whenever the door
-  // does not re-export the symbol, which is the common case.
   it("offers no autofix", () => {
     expect(plugin.rules.entry.meta?.fixable).toBeUndefined();
   });
@@ -82,8 +74,6 @@ describe("entry rule", () => {
     expect(messages).toEqual([]);
   });
 
-  // The ratchet: a folder with no entry is not a gate, so nothing is demanded
-  // of it. Adding a door later is what turns the boundary on.
   it("says nothing about a directory with no entry file", async () => {
     const messages = await lintEntryFixture("entry-no-door-ok", {
       root: "src",
@@ -91,10 +81,6 @@ describe("entry rule", () => {
     expect(messages).toEqual([]);
   });
 
-  // Landing on any entry file is legal, including a nested module's own -
-  // you need not enter through the outermost door. Only the reach past
-  // every door is reported, and it names Inner, the innermost gate, because
-  // that is the one-edit fix.
   it("allows a child's door and names the innermost gate", async () => {
     const messages = await lintEntryFixture("entry-nested-doors", {
       root: "src",
@@ -125,8 +111,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // A type is part of the surface, and the graph records no import kind, so
-  // there is nothing to exempt even if we wanted to.
   it("reports a type-only import that reaches past an entry", async () => {
     const messages = await lintEntryFixture("entry-type-only", { root: "src" });
     expect(messages).toEqual([
@@ -140,11 +124,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // No barrel exemption: re-exporting a private file under a public name is a
-  // worse leak than importing it directly. The barrel also re-exports two
-  // same-directory siblings (a.ts, b.ts) so it qualifies as a namespace
-  // barrel under ownership's sibling-scoped predicate - the point is that an
-  // isNamespaceBarrel-style exemption here would wrongly swallow both findings.
   it("reports a barrel that re-exports past an entry", async () => {
     const messages = await lintEntryFixture("entry-reexport-barrel", {
       root: "src",
@@ -169,8 +148,6 @@ describe("entry rule", () => {
 
   it("reports dynamic import and import-equals", async () => {
     const messages = await lintEntryFixture("entry-dynamic", { root: "src" });
-    // Full messages, not just file/line: a weaker assertion would still pass
-    // if the two visitors resolved each other's targets by mistake.
     expect(messages).toEqual([
       {
         file: "src/app.ts",
@@ -191,7 +168,6 @@ describe("entry rule", () => {
 
   it("ignores a require shadowed by a parameter", async () => {
     const messages = await lintEntryFixture("entry-require", { root: "src" });
-    // Only the createRequire-bound call on line 4 is a real require.
     expect(messages).toEqual([
       {
         file: "src/app.ts",
@@ -203,14 +179,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // Regression test for a bug the first pass of this rule shipped with: an
-  // ambient/global `require` (no local declaration at all, which is exactly
-  // what a `.cjs` file's default sourceType and most Node ESLint configs
-  // give you) resolves to a scope variable with `defs: []`. Treating
-  // "no defs" as "shadowed" made the whole CallExpression visitor inert on
-  // real CommonJS - the two cases below reproduce that with no override and
-  // with an explicit globals.node-style config, confirmed to fail (empty
-  // messages) before the `defs.length > 0` guard and pass after.
   it("reports a require() call with no config override at all (.cjs default sourceType)", async () => {
     const cwd = path.join(
       fileURLToPath(new URL(".", import.meta.url)),
@@ -262,27 +230,17 @@ describe("entry rule", () => {
     });
     const results = await eslint.lintFiles(["src/app.ts"]);
     const messages = collectRuleMessages(cwd, results, "entry");
-    // No local `require` binding here at all - `require` resolves straight
-    // to the ambient global declared via `globals`, the near-universal Node
-    // ESLint setup (`globals: globals.node` does the same thing). That
-    // global variable has `defs: []`, which the first pass of this rule
-    // mistook for "shadowed" and so reported nothing.
     expect(messages).toEqual([
       {
         file: "src/app.ts",
         messageId: "reachesPastEntry",
-        line: 5,
+        line: 1,
         message:
           "'Feature/helper.ts' is inside module 'Feature'; import it through 'Feature/Feature.ts', or move it out of 'Feature' if it is not part of it.",
       },
     ]);
   });
 
-  // Espree coverage for the dynamic-import and require() visitors, following
-  // the eslint-disable-ownership-js precedent: TSImportEqualsDeclaration
-  // never fires under Espree, but ImportExpression and the CallExpression
-  // require() visitor are plain ESTree/ESLint-scope machinery and must work
-  // without the TypeScript parser.
   it("reports dynamic import and require() under Espree", async () => {
     const messages = await lintEntryFixture(
       "entry-dynamic-espree",
@@ -308,9 +266,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // graph.ts's isCreateRequireCall accepts a property-access callee
-  // (`mod.createRequire(...)`), not just a bare identifier import - the rule
-  // must recognise the same form or it silently misses a real CJS edge.
   it("recognises require bound via a property-access createRequire call", async () => {
     const messages = await lintEntryFixture(
       "entry-require-createrequire-member",
@@ -335,11 +290,6 @@ describe("entry rule", () => {
     expect(messages).toEqual([]);
   });
 
-  // Control for the test above: without it, the previous [] could just mean
-  // this fixture never produced a finding in the first place. Pinning the
-  // full object (not just a count) is what stops a future change that
-  // relocates or renames the finding from still satisfying a weaker
-  // assertion here - the same reasoning the dynamic-import test above uses.
   it("still reports the same fixture without the ignore glob", async () => {
     const messages = await lintEntryFixture("entry-ignore", { root: "src" });
     expect(messages).toEqual([
@@ -353,13 +303,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // The report lands on the specifier node (not node.body[0] ?? node), so a
-  // line-level eslint-disable-next-line works without the Program-node
-  // workaround ownership needs there - that workaround exists only because
-  // ESLint 10 drops Program-node reports. Because this rule never reports on
-  // Program, it also has no need for ownership's Espree disable twin
-  // (eslint-disable-ownership-js): the parser choice cannot change which
-  // node the report is anchored to.
   it("honours a line-level eslint-disable comment", async () => {
     const messages = await lintEntryFixture("entry-disable", { root: "src" });
     expect(messages).toEqual([]);
@@ -372,17 +315,6 @@ describe("entry rule", () => {
     expect(messages).toEqual([]);
   });
 
-  // resolveRootDir("does-not-exist", cwd) walks up looking for an existing
-  // directory, hits the project boundary (nearest package.json/.git) before
-  // finding one, and falls back to <fixture>/does-not-exist, which is not on
-  // disk - so safeRealpath(rootDir) is undefined and create bails at the
-  // *first* guard (realRootDir === undefined). This same input also fails
-  // isOutsideRoot (path.relative would read "../src/app.ts"), so this test
-  // cannot tell the two guards apart - only statement order decides which
-  // one fires first, and this stays green even if the realpath guard were
-  // deleted. It also leans on entry-reaches-past reporting exactly the one
-  // finding pinned by the first test in this file; a change there would
-  // silently change what "stays silent" is silencing.
   it("stays silent when root does not exist", async () => {
     const messages = await lintEntryFixture("entry-reaches-past", {
       root: "does-not-exist",
@@ -390,8 +322,6 @@ describe("entry rule", () => {
     expect(messages).toEqual([]);
   });
 
-  // Declaration files are excluded from the graph, so an index.d.ts is not a
-  // door and the directory it sits in is not a gate.
   it("does not treat a declaration file as an entry", async () => {
     const messages = await lintEntryFixture("entry-dts-not-a-door", {
       root: "src",
@@ -399,12 +329,6 @@ describe("entry rule", () => {
     expect(messages).toEqual([]);
   });
 
-  // Mirrors robustness.test.ts's "linted file is not on disk" case for
-  // ownership: --stdin-filename, a processor, or a file deleted mid-run all
-  // hand the rule a filename ESLint parsed but that safeRealpath cannot
-  // resolve. realFilename is undefined, so create bails at the same guard
-  // exercised above by the missing-root case - together the two tests cover
-  // both disjuncts of `realRootDir === undefined || realFilename === undefined`.
   it("stays silent when the linted file is not on disk", async () => {
     const cwd = path.join(
       fileURLToPath(new URL(".", import.meta.url)),
@@ -418,12 +342,6 @@ describe("entry rule", () => {
     expect(collectRuleMessages(cwd, results, "entry")).toEqual([]);
   });
 
-  // `import("./x").T` and `typeof import("./x")` are TSImportType, a different
-  // node from ImportExpression, so they reached no visitor at all while the
-  // equivalent `import type { T } from "./x"` was gated. The rule's answer must
-  // not depend on which spelling the author picked - the ungated one is what
-  // generated code and files avoiding top-level imports emit. Line 3 is the
-  // negative control: the same inline spelling landing ON the door is legal.
   it("reports an inline type import that reaches past the entry", async () => {
     const messages = await lintEntryFixture("entry-type-import-node", {
       root: "src",
@@ -434,13 +352,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // A no-substitution template literal is as static as a quoted string, so
-  // leaving it out made backticks a one-character way to launder every crossing
-  // in a file past a rule whose entire purpose is a ratchet. The other two lines
-  // pin the boundaries of that: line 4 resolves only if the *cooked* value is
-  // used (`raw` would leave the p escape in the specifier and resolve
-  // nothing), and line 5 must stay out because a substituted template is not
-  // statically known.
   it("reports a static template-literal specifier and ignores a substituted one", async () => {
     const messages = await lintEntryFixture("entry-template-specifier", {
       root: "src",
@@ -451,10 +362,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // Complements entry-dts-not-a-door, which pins that a .d.ts is not a *door*.
-  // This pins that it is not a *target* either: resolveSpecifier's own probe
-  // still finds types.d.ts for a "./types.d" specifier, and reporting it named
-  // a door that will never re-export the type.
   it("does not report a declaration file as a target", async () => {
     const messages = await lintEntryFixture("entry-dts-target", {
       root: "src",
@@ -462,10 +369,6 @@ describe("entry rule", () => {
     expect(messages).toEqual([]);
   });
 
-  // `var require = createRequire(url)` followed by `var require = 1` leaves
-  // `require` holding a number at the call, so the call loads nothing and there
-  // is no crossing to report. Checking whether *any* def was a createRequire
-  // was order-blind and reported one.
   it("stays silent when a createRequire binding is later clobbered", async () => {
     const messages = await lintEntryFixture("entry-require-redeclared", {
       root: "src",
@@ -473,11 +376,6 @@ describe("entry rule", () => {
     expect(messages).toEqual([]);
   });
 
-  // The deliberate cost of the check above, recorded so a future reader does not
-  // read this silence as the order-blind bug coming back: here `require` really
-  // is the real one at the call, and requiring *every* def to be a createRequire
-  // call gives up the finding. Accepted because a missed report beats a wrong
-  // one, and because both shapes need `require` declared twice in one scope.
   it("gives up the finding when a clobbered require is later reassigned (known false negative)", async () => {
     const messages = await lintEntryFixture("entry-require-redeclared-mirror", {
       root: "src",
@@ -485,12 +383,6 @@ describe("entry rule", () => {
     expect(messages).toEqual([]);
   });
 
-  // Forces findCrossedGate's upward walk to iterate: the target's own directory
-  // (Feature/utils) is not a gate, so the gate is only found one level further
-  // up. Every other fixture puts the target directly inside its gate, which the
-  // first iteration already answers, so nothing pinned the loop - even though
-  // this is the README's headline case. Asserts the whole message, which ties
-  // target, module and entry together.
   it("reports a target several levels below the door", async () => {
     const messages = await lintEntryFixture("entry-deep-past-door", {
       root: "src",
@@ -505,10 +397,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // Featurex is not inside Feature, and the only thing keeping them apart is the
-  // trailing separator in isInsideDir's comparison. Dropping it would make a
-  // prefix-sharing sibling look like it lives inside the gate and silently lose
-  // this report. The message is asserted too, so the named module cannot drift.
   it("reports an importer in a sibling directory sharing a name prefix", async () => {
     const messages = await lintEntryFixture("entry-sibling-prefix", {
       root: "src",
@@ -523,12 +411,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // The rule resolves specifiers with the graph's own settings, which is what
-  // carries the project's `paths`. Losing them would fall back to a lenient
-  // default with no `paths` at all, so every aliased import would resolve to
-  // nothing and the rule would go quiet without anything looking broken. The
-  // fixture's own tsconfig.json is what makes `@/` resolve - no other entry
-  // fixture has one, so nothing else covers aliased resolution.
   it("reports through a tsconfig paths alias", async () => {
     const messages = await lintEntryFixture("entry-paths-alias", {
       root: "src",
@@ -543,9 +425,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // The shadowing binding is a parameter of an enclosing function and the call
-  // sits in a nested arrow, so only a walk up the scope chain finds it - an
-  // immediate-scope-only check would report this.
   it("stays silent for a require shadowed in an enclosing scope", async () => {
     const messages = await lintEntryFixture("entry-require-nested-scope", {
       root: "src",
@@ -553,10 +432,6 @@ describe("entry rule", () => {
     expect(messages).toEqual([]);
   });
 
-  // The mirror case, and the one graph.ts gets wrong (see
-  // docs/agents/known-issues.md): an inner `const require = createRequire(...)`
-  // IS the real require even though an unrelated plain `require` exists in an
-  // outer scope. Shadowing is lexical, not sticky - the nearest binding decides.
   it("reports an inner createRequire beneath an outer shadowed require", async () => {
     const messages = await lintEntryFixture(
       "entry-require-inner-createrequire",
@@ -567,13 +442,6 @@ describe("entry rule", () => {
     ]);
   });
 
-  // The importer needs the graph's casing for the same reason the target does:
-  // realpath does not fold case, so a wrong-case linted path left isInsideDir
-  // comparing it against the gate's real key. It missed, and the file was
-  // reported for reaching into the very directory it lives in - a report whose
-  // only "fix" is to import its own door, i.e. a cycle. Note the contrast with a
-  // wrong-case *root*, which is documented to produce no findings; this produced
-  // wrong ones.
   it.skipIf(ts.sys.useCaseSensitiveFileNames)(
     "stays silent when the importer is linted through a wrong-case path",
     async () => {
@@ -581,9 +449,6 @@ describe("entry rule", () => {
         fileURLToPath(new URL(".", import.meta.url)),
         "fixtures/entry-importer-inside-ok",
       );
-      // Feature/Feature.ts imports its own sibling ./helper, so it is inside the
-      // gate and must never be reported - however the path reaching the rule is
-      // spelled.
       const results = await makeESLint(cwd, { root: "src" }, {
         rule: "entry",
       }).lintFiles(["src/feature/Feature.ts"]);

--- a/tests/fixtures/entry-require-node-globals/src/app.ts
+++ b/tests/fixtures/entry-require-node-globals/src/app.ts
@@ -1,5 +1,1 @@
-// No local `require` binding at all - this exercises the truly ambient
-// global case (Node's CJS globals, `globals: globals.node`, etc.), where
-// `require` resolves to a scope variable with `defs: []` and must not be
-// treated as shadowed.
 export const real = require("./Feature/helper");

--- a/tests/fixtures/entry-require/src/app.ts
+++ b/tests/fixtures/entry-require/src/app.ts
@@ -4,6 +4,5 @@ const require = createRequire(import.meta.url);
 export const real = require("./Feature/helper");
 
 export function shadowed(require: (id: string) => unknown) {
-  // Not the CJS require, so not an edge and not a boundary crossing.
   return require("./Feature/helper");
 }

--- a/tests/gates.test.ts
+++ b/tests/gates.test.ts
@@ -23,8 +23,6 @@ describe("isEntryFile", () => {
     expect(isEntryFile(at("Feature", "helper.ts"))).toBe(false);
   });
 
-  // The ownership model also requires an outside importer for an index; access
-  // does not, or a freshly added door would gate nothing until someone used it.
   it("does not care who imports the entry", () => {
     expect(isEntryFile(at("Untouched", "index.ts"))).toBe(true);
   });
@@ -51,17 +49,11 @@ describe("getGates", () => {
     expect(getGates(graph)).toBe(getGates(graph));
   });
 
-  // graphOf sorts, so a directory-named file always precedes "index" - this
-  // exercises the reverse, where index sorts first, to prove index wins either
-  // way rather than only when it happens to come last.
   it("prefers index over a directory-named sibling even when index sorts first", () => {
     const graph = graphOf(at("zed", "index.ts"), at("zed", "zed.ts"));
     expect(getGates(graph).get(at("zed"))).toBe(at("zed", "index.ts"));
   });
 
-  // Two index spellings mid-migration: both are legal targets, so this pins
-  // the message-wording choice (first in sorted order) rather than asserting
-  // it is somehow the "correct" one.
   it("picks the first index spelling in sorted order when both exist", () => {
     const graph = graphOf(at("Feature", "index.ts"), at("Feature", "index.tsx"));
     expect(getGates(graph).get(at("Feature"))).toBe(at("Feature", "index.ts"));
@@ -89,7 +81,6 @@ describe("findCrossedGate", () => {
     });
   });
 
-  // Nested doors count: landing on any entry is legal, even a child's.
   it("allows an entry file as a target", () => {
     expect(
       findCrossedGate(at("Outer", "Inner", "Inner.ts"), at("app.ts"), graph, root),
@@ -127,10 +118,6 @@ describe("findCrossedGate", () => {
     ).toBeUndefined();
   });
 
-  // A gate directory that already ends in the separator is the filesystem root,
-  // where appending another one builds "//" and matches nothing - so an importer
-  // plainly inside the gate looked outside it. Reachable because resolveRootDir
-  // returns an absolute root verbatim, so root: "/" survives to here.
   it("treats an importer inside a root-level gate as inside it", () => {
     const fsRoot = path.sep;
     const atRoot = (name: string): string => path.join(fsRoot, name);
@@ -140,10 +127,6 @@ describe("findCrossedGate", () => {
     ).toBeUndefined();
   });
 
-  // Featurex is not inside Feature, and the trailing separator in isInsideDir's
-  // comparison is the only thing keeping them apart: without it a prefix-sharing
-  // sibling would look like it lives inside the gate and this report would be
-  // silently dropped.
   it("does not treat a name-prefix sibling as inside the gate", () => {
     const siblings = graphOf(
       at("Feature", "Feature.ts"),

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -191,10 +191,6 @@ describe("getGraph", () => {
     expect(graph.files).toEqual([aPath, bPath]);
   });
 
-  // The entry rule leans on a bare directory specifier resolving through to
-  // its index - if resolution ever stopped doing that, the specifier would
-  // resolve to undefined and every rule built on it would silently stop
-  // seeing the import, not report it wrong.
   it("resolves a bare directory specifier to its index file", () => {
     const base = fs.realpathSync(tempDir("colocate-dir-index-"));
     const srcDir = path.join(base, "src");
@@ -211,11 +207,6 @@ describe("canonicalGraphPath", () => {
   it.skipIf(ts.sys.useCaseSensitiveFileNames)(
     "recovers the graph's own casing for a path resolved through wrong-case specifier text",
     () => {
-      // Reproduces the exact defect this exists to close: fs.realpathSync (what
-      // safeRealpath/resolveSpecifier use) does not fold case on macOS - only
-      // its .native variant does - so resolving "./FEATURE" against a file
-      // actually named Feature.ts hands back .../FEATURE/FEATURE.ts, not the
-      // path the graph itself uses as a gate/owner key.
       const base = fs.realpathSync(tempDir("colocate-canonical-"));
       const srcDir = path.join(base, "src");
       const featureDir = path.join(srcDir, "Feature");
@@ -232,8 +223,6 @@ describe("canonicalGraphPath", () => {
       const graph = getGraph(srcDir, [], entryPath);
       const settings = getGraphResolutionSettings(graph);
 
-      // The false positive: resolving the wrong-case specifier that actually
-      // lands on the door.
       const wrongCaseEntry = resolveSpecifier(
         "./Feature/FEATURE",
         srcDir,
@@ -245,9 +234,6 @@ describe("canonicalGraphPath", () => {
         entryPath,
       );
 
-      // The false negative: resolving a wrong-case directory segment on a
-      // genuine crossing must still land on the graph's real helper path, or
-      // a gate lookup keyed on its directory silently misses.
       const wrongCaseHelper = resolveSpecifier(
         "./feature/helper",
         srcDir,
@@ -281,21 +267,9 @@ describe("canonicalGraphPath", () => {
     );
   });
 
-  // Hand-built rather than written to disk on purpose: the two files differ only
-  // by case, which a case-insensitive volume cannot hold at once. The graph can
-  // still contain both, because ts.sys.useCaseSensitiveFileNames is probed where
-  // TypeScript itself is installed, not where the project lives - a
-  // case-sensitive mount under a case-insensitive host, or Windows per-directory
-  // case sensitivity, makes this the real shape.
   it.skipIf(ts.sys.useCaseSensitiveFileNames)(
     "prefers an exact graph member over the lowercase fold",
     () => {
-      // Foo/index.ts is the door; Foo/Index.ts is an ordinary internal file,
-      // since "Index" is neither "index" nor "Foo". They share one lowercase
-      // key, and the fold keeps whichever came last - so without an exact-match
-      // guard one silently becomes the other: the internal file folds onto the
-      // door and its crossing vanishes, or the door folds onto the internal file
-      // and gets reported as reaching past itself.
       const graph = {
         files: ["/root/Foo/Index.ts", "/root/Foo/index.ts"],
         importers: new Map(),
@@ -306,26 +280,18 @@ describe("canonicalGraphPath", () => {
       expect(canonicalGraphPath(graph, "/root/Foo/index.ts")).toBe(
         "/root/Foo/index.ts",
       );
-      // The recovery path itself must still work for a non-member.
       expect(canonicalGraphPath(graph, "/root/foo/INDEX.ts")).toBe(
         "/root/Foo/index.ts",
       );
     },
   );
 
-  // Runs on every platform, unlike the case tests above: normalization is folded
-  // regardless of whether the filesystem ignores case, because `readdir` reports
-  // whatever form the filesystem stores while a specifier carries whatever form
-  // the author's editor wrote, and neither realpath nor the resolver converts
-  // between them. Both directions matter - a project can be checked out either
-  // way - so both are asserted.
   it("recovers the graph's own spelling across Unicode normalization forms", () => {
     const nfc = "Café"; // é as a single code point
     const nfd = "Café"; // e followed by a combining acute
     expect(nfc).not.toBe(nfd);
     expect(nfc.normalize("NFC")).toBe(nfd.normalize("NFC"));
 
-    // Graph stored NFC, specifier resolved NFD.
     const storedNfc = {
       files: [`/root/${nfc}/inner.ts`],
       importers: new Map(),
@@ -334,7 +300,6 @@ describe("canonicalGraphPath", () => {
       `/root/${nfc}/inner.ts`,
     );
 
-    // Graph stored NFD, specifier resolved NFC.
     const storedNfd = {
       files: [`/root/${nfd}/inner.ts`],
       importers: new Map(),
@@ -343,8 +308,6 @@ describe("canonicalGraphPath", () => {
       `/root/${nfd}/inner.ts`,
     );
 
-    // An exact member still wins, so neither spelling is rewritten when the
-    // graph already holds it verbatim.
     expect(canonicalGraphPath(storedNfc, `/root/${nfc}/inner.ts`)).toBe(
       `/root/${nfc}/inner.ts`,
     );
@@ -352,7 +315,6 @@ describe("canonicalGraphPath", () => {
       `/root/${nfd}/inner.ts`,
     );
 
-    // Still unchanged for a path the graph does not hold in any form.
     expect(canonicalGraphPath(storedNfc, "/root/Other/inner.ts")).toBe(
       "/root/Other/inner.ts",
     );
@@ -384,8 +346,6 @@ describe("getGraphResolutionSettings", () => {
     expect(resolveSpecifier("@/b", srcDir, settings)).toBe(
       path.join(base, "src", "b.ts"),
     );
-    // Pinned on purpose: this is the silent-degradation mode the settings
-    // exist to avoid. Without them, an aliased import resolves to nothing.
     expect(resolveSpecifier("@/b", srcDir)).toBeUndefined();
   });
 

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -9,8 +9,6 @@ describe("fixture harness", () => {
     ]);
   });
 
-  // Entry reports are per-import, so several land in one file and assertions
-  // need to tell them apart.
   it("exposes line and message when a rule is named explicitly", async () => {
     const messages = await lintFixtureRule("singleton-flag", "ownership");
     expect(messages).toHaveLength(1);

--- a/tests/helpers/lint-fixture.ts
+++ b/tests/helpers/lint-fixture.ts
@@ -39,9 +39,6 @@ export function makeESLint(
             ecmaVersion: 2022,
           },
         };
-  // Accepts several rule names so a cache test can enable both rules at once -
-  // that is the configuration that exposed the getGraph double-call bug, and
-  // no fixture-driven assertion needs more than one rule at a time.
   const ruleNames =
     options?.rule === undefined
       ? (["ownership"] as const)
@@ -70,12 +67,6 @@ export function makeESLint(
   });
 }
 
-// The real collection loop lives here so the fatal-parse-error check has one
-// implementation; collectMessages below is a thin projection onto the
-// two-key shape the ownership assertions were already written against.
-// Exported so a temp-directory test for a new rule (the makeESLint +
-// collectMessages idiom in cache.test.ts) doesn't silently get `[]` back
-// from collectMessages's hardcoded "colocate/ownership" filter.
 export function collectRuleMessages(
   cwd: string,
   results: ESLint.LintResult[],
@@ -104,8 +95,6 @@ export function collectRuleMessages(
     }
   }
 
-  // A fixture that stops parsing would otherwise silently satisfy every
-  // "expect no messages" assertion.
   if (fatal.length > 0) {
     throw new Error(`fixture produced parse errors:\n${fatal.join("\n")}`);
   }
@@ -122,10 +111,6 @@ export function collectMessages(
   );
 }
 
-// Ownership assertions compare whole objects with toEqual, so they want the
-// two-key shape below. Reach for lintFixtureRule instead when a fixture
-// packs several findings into one file and the assertion needs line/message
-// to tell them apart.
 export async function lintFixture(
   name: string,
   ruleOptions?: Record<string, unknown>,
@@ -166,16 +151,6 @@ export async function lintEntryFixture(
   return lintFixtureRule(name, "entry", ruleOptions, targets, options);
 }
 
-/**
- * The named keys of each message, for a `toEqual` that pins some fields and
- * ignores the rest.
- *
- * Six copies of `messages.map(({ file, line, messageId }) => ({ file, line,
- * messageId }))` had accumulated in entry.test.ts. Keep choosing the keys per
- * assertion rather than settling on one shape: which fields carry the point
- * differs - `message` is the payload wherever the report names a module and a
- * door, and noise wherever the interesting thing is which line was flagged.
- */
 export function pick<K extends keyof FixtureMessage>(
   messages: FixtureMessage[],
   ...keys: K[]

--- a/tests/owners.test.ts
+++ b/tests/owners.test.ts
@@ -27,11 +27,6 @@ function tempDir(prefix: string): string {
   return dir;
 }
 
-// Whether the filesystem finds an NFD-named file through its NFC spelling.
-// Probed rather than inferred from ts.sys.useCaseSensitiveFileNames: the two are
-// independent axes (a case-sensitive APFS volume still ignores normalization,
-// and ext4 ignores neither), and it is this axis that decides whether the
-// specifier below resolves at all.
 function foldsNormalization(dir: string): boolean {
   const name = "probe-Café.ts";
   fs.writeFileSync(path.join(dir, name.normalize("NFD")), "");
@@ -96,16 +91,6 @@ describe("resolveLayerDirectories", () => {
 });
 
 describe("collectReExports", () => {
-  // The only proof that collectReExports canonicalises its resolved targets
-  // that does not depend on case folding. It matters because the case tests in
-  // ownership.test.ts skip on a case-sensitive volume, and there
-  // canonicalGraphPath folds normalization and nothing else - so without this,
-  // deleting the call outright leaves the whole suite green on Linux.
-  //
-  // Nothing here is hand-built: the file is NFD on disk (so the walk records it
-  // NFD) while the specifier is NFC, which is the real shape - readdir reports
-  // the stored form, an editor writes whatever the author typed, and neither
-  // realpath nor the resolver converts between them.
   it("recovers the graph's spelling of a sibling re-exported in another normalization form", () => {
     const base = fs.realpathSync(tempDir("colocate-reexport-nfd-"));
     if (!foldsNormalization(base)) {
@@ -128,8 +113,6 @@ describe("collectReExports", () => {
     const graph = buildGraph(srcDir, []);
     const { local, total } = collectReExports(indexPath, fooDir, graph);
 
-    // Without the fold this is the NFC path the specifier spelled, which is not
-    // a graph key - graphHasFile rejects it and mismatchedEntry is lost.
     expect(local).toEqual([siblingNfd]);
     expect(graph.files).toContain(local[0]);
     expect(total).toBe(1);

--- a/tests/ownership.test.ts
+++ b/tests/ownership.test.ts
@@ -263,10 +263,6 @@ describe("ownership rule", () => {
     expect(sortMessages(messages)).toEqual([]);
   });
 
-  // The shell reaching past a feature's entry into its internals is a real
-  // finding, not noise: boot.ts is shared by App and Cart while living inside
-  // Cart. Declaring the shell exempt would hide it, which is why there is no
-  // option to do so.
   it("reports a module shared between the app shell and a feature's own tree", async () => {
     const messages = await lintFixture("shell-reaches-internals", {
       root: "src",
@@ -420,11 +416,6 @@ describe("ownership rule", () => {
     ]);
   });
 
-  // The platform-independent half of the mixed-casing test below: the
-  // aggregated count keys on the resolved module, so two spellings of one
-  // module are one module. Keeping this case-free matters because the two
-  // skipIf tests that follow are the only other cover for that keying, and they
-  // do not run on a case-sensitive filesystem.
   it("counts two spellings of one re-exported module as one module", async () => {
     const messages = await lintFixture("extension-split-barrel");
     expect(sortMessages(messages)).toEqual([
@@ -526,10 +517,6 @@ describe("ownership rule", () => {
     },
   );
 
-  // A link out of the root is not followed: such files cannot be reported (they
-  // are outside root) but would still act as owners, which produced phantom
-  // second owners and unactionable reports. The consumer inside vendor/ is
-  // therefore invisible, and helper.ts is judged on its in-root consumer alone.
   it("does not count consumers behind a symlink out of the root", async () => {
     const messages = await lintFixture("symlinked-module", { root: "src" });
     expect(sortMessages(messages)).toEqual([
@@ -662,13 +649,6 @@ describe("ownership rule", () => {
     ]);
   });
 
-  // The one test that pins report ORDER, and the only reason the documented
-  // order is not free to drift. Every other assertion in this file sorts before
-  // comparing, and until this fixture existed no fixture produced two findings
-  // on a single file at all - so swapping the pushes in `ownershipFindings` left
-  // the whole suite green, typecheck clean, and `check:placement` reporting
-  // unsatisfiable=0, because that script only prints its per-placement matrix
-  // when a configuration has no clean placement. Asserted unsorted, on purpose.
   it("emits both findings for one file in the documented order", async () => {
     const messages = await lintFixtureRule(
       "two-findings-one-file",
@@ -678,11 +658,7 @@ describe("ownership rule", () => {
     expect(
       messages.map(({ file, messageId }) => ({ file, messageId })),
     ).toEqual([
-      // singletonFolder first: Widget/ holds one source file named after it and
-      // has no companion stylesheet.
       { file: "src/shared/Widget/Widget.ts", messageId: "singletonFolder" },
-      // then privateOutsideOwner: its only consumer is pages/Home, and it sits
-      // outside that folder. Both are real, and each names a different edit.
       { file: "src/shared/Widget/Widget.ts", messageId: "privateOutsideOwner" },
     ]);
   });

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -20,15 +20,10 @@ describe("isInsideDir", () => {
     expect(isInsideDir(at("p", "src"), at("p", "src"))).toBe(false);
   });
 
-  // The whole reason this module exists: a sibling sharing a name prefix is not
-  // inside, and only the trailing separator distinguishes them.
   it("rejects a sibling whose name merely starts with the directory's", () => {
     expect(isInsideDir(at("p", "srcx", "a.ts"), at("p", "src"))).toBe(false);
   });
 
-  // A dir already ending in the separator is the filesystem root. Appending
-  // another built "//", which matched nothing, so a file plainly inside looked
-  // outside. Reachable because resolveRootDir returns an absolute root verbatim.
   it("handles a directory that already ends in a separator", () => {
     expect(isInsideDir(at("a.ts"), sep)).toBe(true);
     expect(isInsideDir(at("sub", "a.ts"), sep)).toBe(true);
@@ -48,9 +43,6 @@ describe("isAtOrInsideDir", () => {
     expect(isAtOrInsideDir(at("p", "srcx"), at("p", "src"))).toBe(false);
   });
 
-  // graph.ts's copy had the same separator defect: with root "/", every symlink
-  // whose real path differed was judged outside the root and dropped from the
-  // graph entirely.
   it("treats a path under a separator-terminated root as within it", () => {
     expect(isAtOrInsideDir(at("sub", "a.ts"), sep)).toBe(true);
     expect(isAtOrInsideDir(sep, sep)).toBe(true);

--- a/tests/plugin-meta.test.ts
+++ b/tests/plugin-meta.test.ts
@@ -13,8 +13,6 @@ describe("plugin surface", () => {
       fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
     ) as { name: string; version: string };
 
-    // meta.version is hardcoded, so this is the only thing keeping it honest
-    // after a version bump.
     expect(plugin.meta.name).toBe(pkg.name);
     expect(plugin.meta.version).toBe(pkg.version);
   });
@@ -41,8 +39,6 @@ describe("plugin surface", () => {
     ]);
   });
 
-  // Adding a rule to a shipped preset would make every future rule a breaking
-  // change, so the plugin deliberately exports none.
   it("ships no configs", () => {
     expect((plugin as { configs?: unknown }).configs).toBeUndefined();
   });
@@ -59,8 +55,6 @@ describe("stampIsAmbiguous", () => {
     expect(stampIsAmbiguous(4_999_000, builtAt, true)).toBe(false);
   });
 
-  // A clock-skewed future timestamp is stable, so distrusting it would rebuild
-  // the graph on every lint forever.
   it("trusts a stamp from a later second", () => {
     expect(stampIsAmbiguous(5_002_000, builtAt, true)).toBe(false);
   });

--- a/tests/robustness.test.ts
+++ b/tests/robustness.test.ts
@@ -175,11 +175,6 @@ describe("robustness", () => {
     ]);
   });
 
-  // tsc reports a diagnostic for a malformed `paths` entry but still returns the
-  // raw value, so a one-bracket typo reached aliasCandidates as a string and
-  // threw a TypeError out of the rule - killing the whole lint run rather than
-  // degrading to no findings. Covers both rules and both malformed shapes,
-  // because the throw was in shared resolution code, not in either rule.
   it.each([
     ["a string instead of an array", '{ "@/*": "src/*" }'],
     ["a non-string target", '{ "@/*": [{ "not": "a string" }] }'],
@@ -197,8 +192,6 @@ describe("robustness", () => {
         const results = await makeESLint(dir, { root: "src" }, {
           rule,
         }).lintFiles(["src"]);
-        // Not just "no findings": a thrown rule surfaces as a fatal message,
-        // which collectRuleMessages turns into an error, so this asserts both.
         expect(collectRuleMessages(dir, results, rule)).toEqual([]);
       }
     } finally {

--- a/tests/root.test.ts
+++ b/tests/root.test.ts
@@ -44,7 +44,6 @@ describe("resolveRootDir", () => {
     fs.writeFileSync(path.join(project, "package.json"), "{}");
     fs.mkdirSync(path.join(base, "src"));
 
-    // "src" exists above the project, but the walk must stop at the package.json.
     expect(resolveRootDir("src", deep)).toBe(path.join(deep, "src"));
   });
 });

--- a/tests/walk.test.ts
+++ b/tests/walk.test.ts
@@ -280,8 +280,6 @@ describe("caching with a symlinked root", () => {
     const current = path.join(dir, "src/a.ts");
     const other = path.join(dir, "src/b.ts");
 
-    // Pinned to an exact whole-second timestamp both times, so mtime is
-    // genuinely unchanged and only the size differs.
     const pinned = 1_000_000;
     fs.utimesSync(other, pinned, pinned);
     const first = getGraph(root, [], current);
@@ -306,7 +304,6 @@ describe("caching with a symlinked root", () => {
     const first = getGraph(root, [], edited);
     expect(first.importers.get(path.join(dir, "src/x.ts"))).toEqual([edited]);
 
-    // Same byte length, same mtime: only ctime moves, and userland cannot set it.
     fs.writeFileSync(edited, 'import "./y";\n');
     fs.utimesSync(edited, pinned, pinned);
 


### PR DESCRIPTION
## Summary
- Strip prose comments from `src/`, tests, scripts, and rebuilt `dist/`, matching the rule that comments are for humans only.
- Keep linter directives in the eslint-disable fixtures (including the leading-trivia line ESLint 10 needs) and the NFC/NFD labels on the two lookalike strings in `tests/graph.test.ts`.

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run build`


Made with [Cursor](https://cursor.com)