### PR TITLE
Memoize barrel re-export collection

### DIFF
--- a/dist/lib/owners.js
+++ b/dist/lib/owners.js
@@ -8,7 +8,8 @@ import { parseSourceFile } from "./parse.js";
 import { isInsideDir } from "./paths.js";
 import { resolveSpecifier } from "./resolve.js";
 import { SKIP_DIRS } from "./scope.js";
-export function collectReExports(indexFile, dir, graph) {
+const reExportsByGraph = derivedFromGraph(() => new Map());
+function scanReExports(indexFile, dir, graph) {
     const content = safeReadFile(indexFile);
     const realDir = safeRealpath(dir);
     const realIndex = safeRealpath(indexFile);
@@ -39,6 +40,17 @@ export function collectReExports(indexFile, dir, graph) {
     };
     visit(sourceFile);
     return { local: [...local], total: modules.size };
+}
+export function collectReExports(indexFile, dir, graph) {
+    const key = indexFile + "\0" + dir;
+    const perGraph = reExportsByGraph(graph);
+    const cached = perGraph.get(key);
+    if (cached !== undefined) {
+        return cached;
+    }
+    const result = scanReExports(indexFile, dir, graph);
+    perGraph.set(key, result);
+    return result;
 }
 function isNamespaceBarrel(filePath, graph) {
     const basename = path.basename(filePath, path.extname(filePath));

--- a/src/lib/owners.ts
+++ b/src/lib/owners.ts
@@ -26,24 +26,16 @@ export interface ReExports {
 
 const reExportsByGraph = derivedFromGraph(() => new Map<string, ReExports>());
 
-export function collectReExports(
+function scanReExports(
   indexFile: string,
   dir: string,
   graph: Graph,
 ): ReExports {
-  const perGraph = reExportsByGraph(graph);
-  const cached = perGraph.get(indexFile);
-  if (cached !== undefined) {
-    return cached;
-  }
-
   const content = safeReadFile(indexFile);
   const realDir = safeRealpath(dir);
   const realIndex = safeRealpath(indexFile);
   if (content === undefined || realDir === undefined) {
-    const empty = { local: [], total: 0 };
-    perGraph.set(indexFile, empty);
-    return empty;
+    return { local: [], total: 0 };
   }
   const sourceFile = parseSourceFile(indexFile, content);
   const settings = getGraphResolutionSettings(graph);
@@ -73,8 +65,23 @@ export function collectReExports(
   };
 
   visit(sourceFile);
-  const result = { local: [...local], total: modules.size };
-  perGraph.set(indexFile, result);
+  return { local: [...local], total: modules.size };
+}
+
+export function collectReExports(
+  indexFile: string,
+  dir: string,
+  graph: Graph,
+): ReExports {
+  const key = indexFile + "\0" + dir;
+  const perGraph = reExportsByGraph(graph);
+  const cached = perGraph.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const result = scanReExports(indexFile, dir, graph);
+  perGraph.set(key, result);
   return result;
 }
 

--- a/src/lib/owners.ts
+++ b/src/lib/owners.ts
@@ -24,16 +24,26 @@ export interface ReExports {
   total: number;
 }
 
+const reExportsByGraph = derivedFromGraph(() => new Map<string, ReExports>());
+
 export function collectReExports(
   indexFile: string,
   dir: string,
   graph: Graph,
 ): ReExports {
+  const perGraph = reExportsByGraph(graph);
+  const cached = perGraph.get(indexFile);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   const content = safeReadFile(indexFile);
   const realDir = safeRealpath(dir);
   const realIndex = safeRealpath(indexFile);
   if (content === undefined || realDir === undefined) {
-    return { local: [], total: 0 };
+    const empty = { local: [], total: 0 };
+    perGraph.set(indexFile, empty);
+    return empty;
   }
   const sourceFile = parseSourceFile(indexFile, content);
   const settings = getGraphResolutionSettings(graph);
@@ -63,7 +73,9 @@ export function collectReExports(
   };
 
   visit(sourceFile);
-  return { local: [...local], total: modules.size };
+  const result = { local: [...local], total: modules.size };
+  perGraph.set(indexFile, result);
+  return result;
 }
 
 function isNamespaceBarrel(filePath: string, graph: Graph): boolean {

--- a/tests/owners.test.ts
+++ b/tests/owners.test.ts
@@ -136,6 +136,27 @@ describe("collectReExports", () => {
     expect(second).toBe(first);
   });
 
+  it("keys the memo on the directory argument", () => {
+    const base = fs.realpathSync(tempDir("colocate-reexport-memo-"));
+    const srcDir = path.join(base, "src");
+    const fooDir = path.join(srcDir, "Foo");
+    fs.mkdirSync(fooDir, { recursive: true });
+    fs.writeFileSync(path.join(fooDir, "A.ts"), "export const a = 1;\n");
+    fs.writeFileSync(path.join(fooDir, "B.ts"), "export const b = 1;\n");
+    const indexPath = path.join(fooDir, "index.ts");
+    fs.writeFileSync(indexPath, 'export * from "./A";\n');
+    fs.writeFileSync(path.join(srcDir, "app.ts"), 'import "./Foo";\n');
+
+    const graph = buildGraph(srcDir, []);
+    const first = collectReExports(indexPath, fooDir, graph);
+    expect(first.local).toEqual([path.join(fooDir, "A.ts")]);
+
+    const second = collectReExports(indexPath, srcDir, graph);
+
+    expect(second).not.toBe(first);
+    expect(second.local).not.toEqual(first.local);
+  });
+
   it("does not re-read the barrel after the file changes", () => {
     const base = fs.realpathSync(tempDir("colocate-reexport-memo-"));
     const srcDir = path.join(base, "src");

--- a/tests/owners.test.ts
+++ b/tests/owners.test.ts
@@ -117,4 +117,74 @@ describe("collectReExports", () => {
     expect(graph.files).toContain(local[0]);
     expect(total).toBe(1);
   });
+
+  it("memoises per graph and barrel path", () => {
+    const base = fs.realpathSync(tempDir("colocate-reexport-memo-"));
+    const srcDir = path.join(base, "src");
+    const fooDir = path.join(srcDir, "Foo");
+    fs.mkdirSync(fooDir, { recursive: true });
+    fs.writeFileSync(path.join(fooDir, "A.ts"), "export const a = 1;\n");
+    fs.writeFileSync(path.join(fooDir, "B.ts"), "export const b = 1;\n");
+    const indexPath = path.join(fooDir, "index.ts");
+    fs.writeFileSync(indexPath, 'export * from "./A";\n');
+    fs.writeFileSync(path.join(srcDir, "app.ts"), 'import "./Foo";\n');
+
+    const graph = buildGraph(srcDir, []);
+    const first = collectReExports(indexPath, fooDir, graph);
+    const second = collectReExports(indexPath, fooDir, graph);
+
+    expect(second).toBe(first);
+  });
+
+  it("does not re-read the barrel after the file changes", () => {
+    const base = fs.realpathSync(tempDir("colocate-reexport-memo-"));
+    const srcDir = path.join(base, "src");
+    const fooDir = path.join(srcDir, "Foo");
+    fs.mkdirSync(fooDir, { recursive: true });
+    fs.writeFileSync(path.join(fooDir, "A.ts"), "export const a = 1;\n");
+    fs.writeFileSync(path.join(fooDir, "B.ts"), "export const b = 1;\n");
+    const indexPath = path.join(fooDir, "index.ts");
+    fs.writeFileSync(indexPath, 'export * from "./A";\n');
+    fs.writeFileSync(path.join(srcDir, "app.ts"), 'import "./Foo";\n');
+
+    const graph = buildGraph(srcDir, []);
+    const first = collectReExports(indexPath, fooDir, graph);
+    expect(first.local).toEqual([path.join(fooDir, "A.ts")]);
+
+    fs.writeFileSync(
+      indexPath,
+      'export * from "./A";\nexport * from "./B";\n',
+    );
+    const second = collectReExports(indexPath, fooDir, graph);
+
+    expect(second).toBe(first);
+    expect(second.local).toHaveLength(1);
+  });
+
+  it("recomputes for a rebuilt graph", () => {
+    const base = fs.realpathSync(tempDir("colocate-reexport-memo-"));
+    const srcDir = path.join(base, "src");
+    const fooDir = path.join(srcDir, "Foo");
+    fs.mkdirSync(fooDir, { recursive: true });
+    fs.writeFileSync(path.join(fooDir, "A.ts"), "export const a = 1;\n");
+    fs.writeFileSync(path.join(fooDir, "B.ts"), "export const b = 1;\n");
+    const indexPath = path.join(fooDir, "index.ts");
+    fs.writeFileSync(indexPath, 'export * from "./A";\n');
+    fs.writeFileSync(path.join(srcDir, "app.ts"), 'import "./Foo";\n');
+
+    const graph = buildGraph(srcDir, []);
+    const first = collectReExports(indexPath, fooDir, graph);
+
+    fs.writeFileSync(
+      indexPath,
+      'export * from "./A";\nexport * from "./B";\n',
+    );
+    const graph2 = buildGraph(srcDir, []);
+    const second = collectReExports(indexPath, fooDir, graph2);
+
+    expect(second).not.toBe(first);
+    expect(second.local).toHaveLength(2);
+    expect(second.local).toContain(path.join(fooDir, "A.ts"));
+    expect(second.local).toContain(path.join(fooDir, "B.ts"));
+  });
 });


### PR DESCRIPTION
## Summary

The ownership rule reads each barrel file many times in one lint run. This change stores the re-export result for the life of one import graph. A later call for the same barrel on the same graph returns the stored result. The rule does not add warnings. The rule does not remove warnings.

Fixes #15.

## Relevant files

- `src/lib/owners.ts` — `collectReExports` looks up a map on the graph. `scanReExports` reads and parses the file.
- `tests/owners.test.ts` — tests for store, no second read, new graph, and directory key.
- `dist/lib/owners.js` — published build of the same change.

## Verify

1. Run `npx vitest run tests/owners.test.ts`.
2. Confirm `memoises per graph and barrel path` passes: two calls on the same graph return the same object.
3. Confirm `does not re-read the barrel after the file changes` passes: a disk change does not change the stored result.
4. Confirm `recomputes for a rebuilt graph` passes: a new graph sees the new file contents.
5. Run `npx vitest run tests/ownership.test.ts`. Confirm the same warnings as before.
6. Run `npm test` and `npm run typecheck`.

## Remaining review findings (optional)

1. **Rewrite (not done):** A keyed map helper in `derived.ts` would remove a second copy of the get-or-set pattern. That change is a rewrite of the derived-index helper. This PR does not do it.
2. **Nit:** The memo tests repeat the same temp tree. Low cost.


Made with [Cursor](https://cursor.com)