### PR TITLE
Index graph files by directory (#28)

### DIFF
--- a/dist/lib/findings.js
+++ b/dist/lib/findings.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { safeReaddir, safeStat } from "./fs-safe.js";
-import { graphHasFile } from "./graph.js";
+import { graphFilesInDir, graphHasFile } from "./graph.js";
 import { collectReExports, getSharedColocationIssue, isPrivateOutsideOwner, resolveLayerDirectories, } from "./owners.js";
 import { isSourceFile, isTestFile, matchesIgnore, SKIP_DIRS, } from "./scope.js";
 const STYLESHEET_EXTS = [".css", ".scss", ".sass", ".less", ".styl"];
@@ -63,7 +63,7 @@ function isMismatchedEntry(indexFile, ctx) {
     if (dir === ctx.rootDir) {
         return false;
     }
-    const filesInDir = ctx.graph.files.filter((file) => path.dirname(file) === dir);
+    const filesInDir = graphFilesInDir(ctx.graph, dir);
     const outsideImporters = new Set();
     let allOutsideImportsTargetIndex = true;
     for (const fileInDir of filesInDir) {

--- a/dist/lib/graph.d.ts
+++ b/dist/lib/graph.d.ts
@@ -4,6 +4,7 @@ export interface Graph {
     readonly files: readonly string[];
 }
 export declare function graphHasFile(graph: Graph, filePath: string): boolean;
+export declare function graphFilesInDir(graph: Graph, dir: string): readonly string[];
 export declare function canonicalGraphPath(graph: Graph, filePath: string): string;
 export declare const getGraphResolutionSettings: ((graph: Graph) => ResolutionSettings) & {
     prime: (graph: Graph, value: ResolutionSettings) => void;

--- a/dist/lib/graph.js
+++ b/dist/lib/graph.js
@@ -9,6 +9,23 @@ const graphFileSet = derivedFromGraph((graph) => new Set(graph.files));
 export function graphHasFile(graph, filePath) {
     return graphFileSet(graph).has(filePath);
 }
+const graphFilesByDir = derivedFromGraph((graph) => {
+    const byDir = new Map();
+    for (const file of graph.files) {
+        const dir = path.dirname(file);
+        const list = byDir.get(dir);
+        if (list === undefined) {
+            byDir.set(dir, [file]);
+        }
+        else {
+            list.push(file);
+        }
+    }
+    return byDir;
+});
+export function graphFilesInDir(graph, dir) {
+    return graphFilesByDir(graph).get(dir) ?? [];
+}
 function foldGraphPath(filePath) {
     const normalized = filePath.normalize("NFC");
     return ts.sys.useCaseSensitiveFileNames
@@ -77,6 +94,18 @@ export function buildGraphFromFiles(files, resolvedRoot) {
     getGraphResolutionSettings.prime(graph, settings);
     graphFileSet.prime(graph, fileSet);
     graphFilesByFoldedPath.prime(graph, filesByFoldedPath);
+    const filesByDir = new Map();
+    for (const file of files) {
+        const dir = path.dirname(file);
+        const list = filesByDir.get(dir);
+        if (list === undefined) {
+            filesByDir.set(dir, [file]);
+        }
+        else {
+            list.push(file);
+        }
+    }
+    graphFilesByDir.prime(graph, filesByDir);
     return { graph, configPaths: settings.configPaths };
 }
 export function buildGraphWithConfigs(rootDir, ignoreGlobs) {

--- a/dist/lib/graph.js
+++ b/dist/lib/graph.js
@@ -9,9 +9,9 @@ const graphFileSet = derivedFromGraph((graph) => new Set(graph.files));
 export function graphHasFile(graph, filePath) {
     return graphFileSet(graph).has(filePath);
 }
-const graphFilesByDir = derivedFromGraph((graph) => {
+function filesByParentDir(files) {
     const byDir = new Map();
-    for (const file of graph.files) {
+    for (const file of files) {
         const dir = path.dirname(file);
         const list = byDir.get(dir);
         if (list === undefined) {
@@ -22,7 +22,8 @@ const graphFilesByDir = derivedFromGraph((graph) => {
         }
     }
     return byDir;
-});
+}
+const graphFilesByDir = derivedFromGraph((graph) => filesByParentDir(graph.files));
 export function graphFilesInDir(graph, dir) {
     return graphFilesByDir(graph).get(dir) ?? [];
 }
@@ -94,18 +95,7 @@ export function buildGraphFromFiles(files, resolvedRoot) {
     getGraphResolutionSettings.prime(graph, settings);
     graphFileSet.prime(graph, fileSet);
     graphFilesByFoldedPath.prime(graph, filesByFoldedPath);
-    const filesByDir = new Map();
-    for (const file of files) {
-        const dir = path.dirname(file);
-        const list = filesByDir.get(dir);
-        if (list === undefined) {
-            filesByDir.set(dir, [file]);
-        }
-        else {
-            list.push(file);
-        }
-    }
-    graphFilesByDir.prime(graph, filesByDir);
+    graphFilesByDir.prime(graph, filesByParentDir(files));
     return { graph, configPaths: settings.configPaths };
 }
 export function buildGraphWithConfigs(rootDir, ignoreGlobs) {

--- a/dist/lib/owners.js
+++ b/dist/lib/owners.js
@@ -3,7 +3,7 @@ import { minimatch } from "minimatch";
 import ts from "typescript";
 import { derivedFromGraph } from "./derived.js";
 import { safeReadFile, safeReaddir, safeRealpath } from "./fs-safe.js";
-import { canonicalGraphPath, getGraphResolutionSettings, } from "./graph.js";
+import { canonicalGraphPath, getGraphResolutionSettings, graphFilesInDir, } from "./graph.js";
 import { parseSourceFile } from "./parse.js";
 import { isInsideDir } from "./paths.js";
 import { resolveSpecifier } from "./resolve.js";
@@ -73,7 +73,7 @@ function isOwnerEntryFile(file, dir, graph) {
     return (graph.importers.get(file) ?? []).some((importer) => path.dirname(importer) !== dir);
 }
 function directoryHasMatchingEntry(dir, graph) {
-    return graph.files.some((file) => isOwnerEntryFile(file, dir, graph));
+    return graphFilesInDir(graph, dir).some((file) => isOwnerEntryFile(file, dir, graph));
 }
 export function getOwner(filePath, graph, rootDir) {
     let dir = path.dirname(filePath);

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -30,7 +30,7 @@ scripts/check-placement.ts  opt-in satisfiability sweep, both rules
 
 ## Derived indexes
 
-Every per-graph derived index — resolution settings, the member and folded-path indexes, gates, shells, layer directories — goes through `derivedFromGraph` in `src/lib/derived.ts`: do not hand-roll another `WeakMap<Graph, X>`, and do not hang feature state on `Graph` (it is `readonly` precisely so those indexes can be trusted for the graph's lifetime). Membership is one of those indexes: ask `graphHasFile` from `graph.ts`, never `new Set(graph.files)` per lint.
+Every per-graph derived index — resolution settings, the member and folded-path indexes, files-by-directory, gates, shells, layer directories — goes through `derivedFromGraph` in `src/lib/derived.ts`: do not hand-roll another `WeakMap<Graph, X>`, and do not hang feature state on `Graph` (it is `readonly` precisely so those indexes can be trusted for the graph's lifetime). Membership is one of those indexes: ask `graphHasFile` from `graph.ts`, never `new Set(graph.files)` per lint. Files in a directory are another: ask `graphFilesInDir`, never `graph.files.filter` by dirname.
 
 ## Rule adapters
 

--- a/docs/agents/invariants.md
+++ b/docs/agents/invariants.md
@@ -13,7 +13,7 @@
 - `isInsideDir` has **exactly one** implementation, `src/lib/paths.ts`. Do not reintroduce a local copy.
 - "Is this path in the model" is `isInGraphScope` in `src/lib/scope.ts`; the rule-side preamble is `resolveSubject` in `src/lib/subject.ts`. Use `subject.covers` for a resolved target.
 - Three `Subject` asymmetries must survive tidying: `rootDir` is not realpathed; the linted file is not extension-tested again after realpath; `lintedPath` is only for `mismatchedEntry`. Details: [architecture](architecture.md).
-- Every per-graph derived index goes through `derivedFromGraph`. Ask `graphHasFile`, never `new Set(graph.files)` per lint.
+- Every per-graph derived index goes through `derivedFromGraph`. Ask `graphHasFile`, never `new Set(graph.files)` per lint. Ask `graphFilesInDir` for files in a directory, never `graph.files.some/filter` by `path.dirname`.
 - `canonicalGraphPath` is applied at the `entry` importer/target and at `collectReExports` only. Do not spread it as a general rule. Details: [graph](graph.md).
 - The `getGraph` elapsed-time bound (`REVALIDATE_AFTER_MS`) is load-bearing and must not be dropped. Details: [graph](graph.md).
 - Every report must be fixable. `check:placement` guards that. Do not delete or sort `two-findings-one-file`.

--- a/src/lib/findings.ts
+++ b/src/lib/findings.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { safeReaddir, safeStat } from "./fs-safe.js";
-import { graphHasFile } from "./graph.js";
+import { graphFilesInDir, graphHasFile } from "./graph.js";
 import {
   collectReExports,
   getSharedColocationIssue,
@@ -107,9 +107,7 @@ function isMismatchedEntry(indexFile: string, ctx: OwnershipContext): boolean {
     return false;
   }
 
-  const filesInDir = ctx.graph.files.filter(
-    (file) => path.dirname(file) === dir,
-  );
+  const filesInDir = graphFilesInDir(ctx.graph, dir);
 
   const outsideImporters = new Set<string>();
   let allOutsideImportsTargetIndex = true;

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -17,6 +17,27 @@ export function graphHasFile(graph: Graph, filePath: string): boolean {
   return graphFileSet(graph).has(filePath);
 }
 
+const graphFilesByDir = derivedFromGraph((graph) => {
+  const byDir = new Map<string, string[]>();
+  for (const file of graph.files) {
+    const dir = path.dirname(file);
+    const list = byDir.get(dir);
+    if (list === undefined) {
+      byDir.set(dir, [file]);
+    } else {
+      list.push(file);
+    }
+  }
+  return byDir;
+});
+
+export function graphFilesInDir(
+  graph: Graph,
+  dir: string,
+): readonly string[] {
+  return graphFilesByDir(graph).get(dir) ?? [];
+}
+
 function foldGraphPath(filePath: string): string {
   const normalized = filePath.normalize("NFC");
   return ts.sys.useCaseSensitiveFileNames
@@ -118,6 +139,17 @@ export function buildGraphFromFiles(
   getGraphResolutionSettings.prime(graph, settings);
   graphFileSet.prime(graph, fileSet);
   graphFilesByFoldedPath.prime(graph, filesByFoldedPath);
+  const filesByDir = new Map<string, string[]>();
+  for (const file of files) {
+    const dir = path.dirname(file);
+    const list = filesByDir.get(dir);
+    if (list === undefined) {
+      filesByDir.set(dir, [file]);
+    } else {
+      list.push(file);
+    }
+  }
+  graphFilesByDir.prime(graph, filesByDir);
   return { graph, configPaths: settings.configPaths };
 }
 

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -17,9 +17,9 @@ export function graphHasFile(graph: Graph, filePath: string): boolean {
   return graphFileSet(graph).has(filePath);
 }
 
-const graphFilesByDir = derivedFromGraph((graph) => {
+function filesByParentDir(files: readonly string[]): Map<string, string[]> {
   const byDir = new Map<string, string[]>();
-  for (const file of graph.files) {
+  for (const file of files) {
     const dir = path.dirname(file);
     const list = byDir.get(dir);
     if (list === undefined) {
@@ -29,7 +29,11 @@ const graphFilesByDir = derivedFromGraph((graph) => {
     }
   }
   return byDir;
-});
+}
+
+const graphFilesByDir = derivedFromGraph((graph) =>
+  filesByParentDir(graph.files),
+);
 
 export function graphFilesInDir(
   graph: Graph,
@@ -139,17 +143,7 @@ export function buildGraphFromFiles(
   getGraphResolutionSettings.prime(graph, settings);
   graphFileSet.prime(graph, fileSet);
   graphFilesByFoldedPath.prime(graph, filesByFoldedPath);
-  const filesByDir = new Map<string, string[]>();
-  for (const file of files) {
-    const dir = path.dirname(file);
-    const list = filesByDir.get(dir);
-    if (list === undefined) {
-      filesByDir.set(dir, [file]);
-    } else {
-      list.push(file);
-    }
-  }
-  graphFilesByDir.prime(graph, filesByDir);
+  graphFilesByDir.prime(graph, filesByParentDir(files));
   return { graph, configPaths: settings.configPaths };
 }
 

--- a/src/lib/owners.ts
+++ b/src/lib/owners.ts
@@ -6,6 +6,7 @@ import { safeReadFile, safeReaddir, safeRealpath } from "./fs-safe.js";
 import {
   canonicalGraphPath,
   getGraphResolutionSettings,
+  graphFilesInDir,
   type Graph,
 } from "./graph.js";
 import { parseSourceFile } from "./parse.js";
@@ -112,7 +113,9 @@ function isOwnerEntryFile(file: string, dir: string, graph: Graph): boolean {
 }
 
 function directoryHasMatchingEntry(dir: string, graph: Graph): boolean {
-  return graph.files.some((file) => isOwnerEntryFile(file, dir, graph));
+  return graphFilesInDir(graph, dir).some((file) =>
+    isOwnerEntryFile(file, dir, graph),
+  );
 }
 
 export interface Owner {

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -9,6 +9,7 @@ import {
   buildGraph,
   canonicalGraphPath,
   getGraphResolutionSettings,
+  graphFilesInDir,
 } from "../src/lib/graph.js";
 import {
   createResolutionSettings,
@@ -487,6 +488,26 @@ describe("canonicalGraphPath", () => {
     expect(canonicalGraphPath(storedNfc, "/root/Other/inner.ts")).toBe(
       "/root/Other/inner.ts",
     );
+  });
+});
+
+describe("graphFilesInDir", () => {
+  it("returns graph files in a directory sorted by path", () => {
+    const base = fs.realpathSync(tempDir("colocate-files-by-dir-"));
+    const srcDir = path.join(base, "src");
+    const featDir = path.join(srcDir, "feat");
+    fs.mkdirSync(featDir, { recursive: true });
+    fs.writeFileSync(path.join(srcDir, "a.ts"), "export const a = 1;\n");
+    fs.writeFileSync(path.join(srcDir, "b.ts"), "export const b = 1;\n");
+    fs.writeFileSync(path.join(featDir, "Feat.ts"), "export const Feat = 1;\n");
+    const aPath = fs.realpathSync(path.join(srcDir, "a.ts"));
+    const bPath = fs.realpathSync(path.join(srcDir, "b.ts"));
+    const featPath = fs.realpathSync(path.join(featDir, "Feat.ts"));
+    const graph = buildGraph(srcDir, []);
+
+    expect(graphFilesInDir(graph, srcDir)).toEqual([aPath, bPath]);
+    expect(graphFilesInDir(graph, featDir)).toEqual([featPath]);
+    expect(graphFilesInDir(graph, path.join(srcDir, "missing"))).toEqual([]);
   });
 });
 

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -10,6 +10,7 @@ import {
   canonicalGraphPath,
   getGraphResolutionSettings,
   graphFilesInDir,
+  type Graph,
 } from "../src/lib/graph.js";
 import {
   createResolutionSettings,
@@ -492,7 +493,7 @@ describe("canonicalGraphPath", () => {
 });
 
 describe("graphFilesInDir", () => {
-  it("returns graph files in a directory sorted by path", () => {
+  it("returns graph files in a directory in graph.files order", () => {
     const base = fs.realpathSync(tempDir("colocate-files-by-dir-"));
     const srcDir = path.join(base, "src");
     const featDir = path.join(srcDir, "feat");
@@ -507,6 +508,31 @@ describe("graphFilesInDir", () => {
 
     expect(graphFilesInDir(graph, srcDir)).toEqual([aPath, bPath]);
     expect(graphFilesInDir(graph, featDir)).toEqual([featPath]);
+    expect(graphFilesInDir(graph, path.join(srcDir, "missing"))).toEqual([]);
+  });
+
+  it("works on an unprimed graph via the derived factory", () => {
+    const base = fs.realpathSync(tempDir("colocate-files-by-dir-unprimed-"));
+    const srcDir = path.join(base, "src");
+    const featDir = path.join(srcDir, "feat");
+    fs.mkdirSync(featDir, { recursive: true });
+    fs.writeFileSync(path.join(srcDir, "a.ts"), "export const a = 1;\n");
+    fs.writeFileSync(path.join(srcDir, "b.ts"), "export const b = 1;\n");
+    fs.writeFileSync(path.join(featDir, "Feat.ts"), "export const Feat = 1;\n");
+    const aPath = fs.realpathSync(path.join(srcDir, "a.ts"));
+    const bPath = fs.realpathSync(path.join(srcDir, "b.ts"));
+    const featPath = fs.realpathSync(path.join(featDir, "Feat.ts"));
+    const graph: Graph = {
+      files: [aPath, bPath, featPath],
+      importers: new Map(),
+    };
+
+    expect(new Set(graphFilesInDir(graph, srcDir))).toEqual(
+      new Set([aPath, bPath]),
+    );
+    expect(new Set(graphFilesInDir(graph, featDir))).toEqual(
+      new Set([featPath]),
+    );
     expect(graphFilesInDir(graph, path.join(srcDir, "missing"))).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Close #28. Owner lookup no longer walks every file in the graph.
- Add a per-graph index of files by parent directory. Owner detection and mismatched-entry use that list only.
- Reports stay the same. Cost for `getOwner` on ~3500 files drops from hundreds of milliseconds to tens.

## Files
- `src/lib/graph.ts` — `graphFilesInDir` and the directory index
- `src/lib/owners.ts` — owner-entry check uses the index
- `src/lib/findings.ts` — mismatched-entry uses the index
- `tests/graph.test.ts` — primed and unprimed lookups
- `docs/agents/architecture.md`, `docs/agents/invariants.md` — tell callers to use the index
- `dist/` — published build

## Test plan
- [ ] `npm test`
- [ ] `npm run typecheck`
- [ ] Confirm `two-findings-one-file` still asserts report order without a sort
- [ ] `SKIP_ESLINT=1 SIZES=4000 npx vite-node scripts/measure-perf.ts` — `getOwner all files` must be tens of milliseconds, not hundreds

## Optional review notes
1. `graphFilesInDir` returns the live bucket array. The type is `readonly`, but a caller could still mutate it. Freeze the buckets and reuse one empty array if you want a harder contract. Left as-is: no current caller writes to the result.


Made with [Cursor](https://cursor.com)