### PR TITLE
Add tests for import() inside lazy(() => ...)

### DIFF
--- a/tests/entry.test.ts
+++ b/tests/entry.test.ts
@@ -166,6 +166,19 @@ describe("entry rule", () => {
     ]);
   });
 
+  it("reports dynamic import nested in lazy(() => import())", async () => {
+    const messages = await lintEntryFixture("entry-lazy-import", { root: "src" });
+    expect(messages).toEqual([
+      {
+        file: "src/app.ts",
+        messageId: "reachesPastEntry",
+        line: 1,
+        message:
+          "'Feature/helper.ts' is inside module 'Feature'; import it through 'Feature/Feature.ts', or move it out of 'Feature' if it is not part of it.",
+      },
+    ]);
+  });
+
   it("ignores a require shadowed by a parameter", async () => {
     const messages = await lintEntryFixture("entry-require", { root: "src" });
     expect(messages).toEqual([

--- a/tests/fixtures/entry-lazy-import/src/Feature/Feature.ts
+++ b/tests/fixtures/entry-lazy-import/src/Feature/Feature.ts
@@ -1,0 +1,1 @@
+export const Feature = 1;

--- a/tests/fixtures/entry-lazy-import/src/Feature/helper.ts
+++ b/tests/fixtures/entry-lazy-import/src/Feature/helper.ts
@@ -1,0 +1,1 @@
+export const helper = 2;

--- a/tests/fixtures/entry-lazy-import/src/app.ts
+++ b/tests/fixtures/entry-lazy-import/src/app.ts
@@ -1,0 +1,1 @@
+const Page = lazy(() => import("./Feature/helper"));

--- a/tests/fixtures/private-lazy-import/src/pages/App.ts
+++ b/tests/fixtures/private-lazy-import/src/pages/App.ts
@@ -1,0 +1,1 @@
+import "./MyPage/MyPage";

--- a/tests/fixtures/private-lazy-import/src/pages/MyPage/MyPage.ts
+++ b/tests/fixtures/private-lazy-import/src/pages/MyPage/MyPage.ts
@@ -1,0 +1,1 @@
+const Page = lazy(() => import("../helper"));

--- a/tests/fixtures/private-lazy-import/src/pages/main.ts
+++ b/tests/fixtures/private-lazy-import/src/pages/main.ts
@@ -1,0 +1,1 @@
+import "./App";

--- a/tests/ownership.test.ts
+++ b/tests/ownership.test.ts
@@ -151,6 +151,14 @@ describe("ownership rule", () => {
     ]);
   });
 
+  it("reports privateOutsideOwner when the only importer is nested in lazy(() => import())", async () => {
+    const messages = await lintFixture("private-lazy-import");
+    expect(sortMessages(messages)).toEqual([
+      { file: "src/pages/helper.ts", messageId: "privateOutsideOwner" },
+      { file: "src/pages/MyPage/MyPage.ts", messageId: "singletonFolder" },
+    ]);
+  });
+
   it("does not report privateOutsideOwner when a private file sits inside its owner folder", async () => {
     const messages = await lintFixture("private-colocated-ok");
     expect(sortMessages(messages)).toEqual([]);

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -31,6 +31,15 @@ describe("extractSpecifiers", () => {
     expect(extractSpecifiers('require("./mod");\n', "a.js")).toEqual(["./mod"]);
   });
 
+  it("records import() nested in lazy(() => import())", () => {
+    expect(
+      extractSpecifiers(
+        'const Page = lazy(() => import("./mod"));\n',
+        "a.ts",
+      ),
+    ).toEqual(["./mod"]);
+  });
+
   it("records import() with a no-substitution template specifier", () => {
     expect(extractSpecifiers("import(`./mod`);\n", "a.ts")).toEqual(["./mod"]);
   });


### PR DESCRIPTION
## Summary

- Add tests so `const Page = lazy(() => import("…"))` still counts as an import.
- Closes #30.

The plugin already records this form. The tests exist so a later change cannot drop it without a failure.

## Relevant files

- `tests/parse.test.ts` — records `./mod` from `lazy(() => import("./mod"))`.
- `tests/ownership.test.ts` and `tests/fixtures/private-lazy-import/` — a private helper imported only through that form still reports `privateOutsideOwner`.
- `tests/entry.test.ts` and `tests/fixtures/entry-lazy-import/` — the same form still reports `reachesPastEntry` when it goes past a module door.

## Test plan

- [ ] Run `npm test`.
- [ ] Confirm `extractSpecifiers('const Page = lazy(() => import("./mod"));\n', "a.ts")` returns `["./mod"]`.
- [ ] Confirm fixture `private-lazy-import` reports `privateOutsideOwner` on `src/pages/helper.ts` and `singletonFolder` on `src/pages/MyPage/MyPage.ts`.
- [ ] Confirm fixture `entry-lazy-import` reports `reachesPastEntry` on `src/app.ts` line 1, and names `Feature/helper.ts` and the `Feature` door.

## Remaining review findings

None.


Made with [Cursor](https://cursor.com)