### PR TITLE
Memoize singleton walks and the resolved lint root

### DIFF
--- a/dist/lib/findings.d.ts
+++ b/dist/lib/findings.d.ts
@@ -1,3 +1,9 @@
+import type { Graph } from "./graph.js";
 import type { Subject } from "./subject.js";
+export interface SingletonDirectoryStats {
+    sourceCount: number;
+    hasStylesheet: boolean;
+}
 export type OwnershipFinding = "singletonFolder" | "privateOutsideOwner" | "sharedTooHigh" | "sharedInsideOwner";
+export declare function singletonDirectoryStats(dir: string, rootDir: string, ignore: string[], graph: Graph): SingletonDirectoryStats;
 export declare function ownershipFindings(subject: Subject, cwd: string, layers: string[]): OwnershipFinding[];

--- a/dist/lib/findings.js
+++ b/dist/lib/findings.js
@@ -1,7 +1,9 @@
 import path from "node:path";
+import { derivedFromGraph } from "./derived.js";
 import { safeReaddir, safeStat } from "./fs-safe.js";
 import { getSharedColocationIssue, isPrivateOutsideOwner, resolveLayerDirectories, } from "./owners.js";
 import { isSourceFile, isTestFile, matchesIgnore, SKIP_DIRS, } from "./scope.js";
+const singletonStatsByGraph = derivedFromGraph(() => new Map());
 const STYLESHEET_EXTS = [".css", ".scss", ".sass", ".less", ".styl"];
 function isStylesheet(filePath) {
     const basename = path.basename(filePath);
@@ -24,6 +26,9 @@ function countSourceFilesRecursive(dir, rootDir, ignore) {
                 continue;
             }
             sourceCount += countSourceFilesRecursive(fullPath, rootDir, ignore);
+            if (sourceCount > 1) {
+                return sourceCount;
+            }
             continue;
         }
         const isFile = entry.isSymbolicLink()
@@ -34,9 +39,24 @@ function countSourceFilesRecursive(dir, rootDir, ignore) {
         }
         if (isSourceFile(fullPath) && !isTestFile(relPath)) {
             sourceCount += 1;
+            if (sourceCount > 1) {
+                return sourceCount;
+            }
         }
     }
     return sourceCount;
+}
+export function singletonDirectoryStats(dir, rootDir, ignore, graph) {
+    const cache = singletonStatsByGraph(graph);
+    const cached = cache.get(dir);
+    if (cached !== undefined) {
+        return cached;
+    }
+    const sourceCount = countSourceFilesRecursive(dir, rootDir, ignore);
+    const hasStylesheet = sourceCount === 1 && hasCompanionStylesheet(dir);
+    const stats = { sourceCount, hasStylesheet };
+    cache.set(dir, stats);
+    return stats;
 }
 function hasCompanionStylesheet(dir) {
     return safeReaddir(dir).some((entry) => {
@@ -48,9 +68,9 @@ function hasCompanionStylesheet(dir) {
             : entry.isFile();
     });
 }
-function isSingletonWrapperDirectory(dir, filename, rootDir, ignore) {
-    if (countSourceFilesRecursive(dir, rootDir, ignore) !== 1 ||
-        hasCompanionStylesheet(dir)) {
+function isSingletonWrapperDirectory(dir, filename, rootDir, ignore, graph) {
+    const { sourceCount, hasStylesheet } = singletonDirectoryStats(dir, rootDir, ignore, graph);
+    if (sourceCount !== 1 || hasStylesheet) {
         return false;
     }
     const dirName = path.basename(dir);
@@ -68,7 +88,7 @@ export function ownershipFindings(subject, cwd, layers) {
     };
     const findings = [];
     if (dir !== rootDir &&
-        isSingletonWrapperDirectory(dir, file, rootDir, ignore)) {
+        isSingletonWrapperDirectory(dir, file, rootDir, ignore, graph)) {
         findings.push("singletonFolder");
     }
     if (isPrivateOutsideOwner(file, ctx)) {

--- a/dist/lib/subject.d.ts
+++ b/dist/lib/subject.d.ts
@@ -9,4 +9,8 @@ export interface Subject {
     covers(filePath: string): boolean;
     display(filePath: string): string;
 }
+export declare function resolvedLintRoot(cwd: string, rootOption: string): {
+    rootDir: string;
+    realRootDir: string;
+} | undefined;
 export declare function resolveSubject(context: Rule.RuleContext): Subject | undefined;

--- a/dist/lib/subject.js
+++ b/dist/lib/subject.js
@@ -3,18 +3,47 @@ import { safeRealpath } from "./fs-safe.js";
 import { getGraph } from "./graph-cache.js";
 import { resolveRootDir } from "./root.js";
 import { isInGraphScope, isSourceFile } from "./scope.js";
+const resolvedLintRoots = new Map();
+const fileRealpathsByParse = new WeakMap();
+export function resolvedLintRoot(cwd, rootOption) {
+    const key = cwd + "\0" + rootOption;
+    const cached = resolvedLintRoots.get(key);
+    if (cached !== undefined) {
+        return cached;
+    }
+    const rootDir = resolveRootDir(rootOption, cwd);
+    const realRootDir = safeRealpath(rootDir);
+    if (realRootDir === undefined) {
+        return undefined;
+    }
+    const resolved = { rootDir, realRootDir };
+    resolvedLintRoots.set(key, resolved);
+    return resolved;
+}
 export function resolveSubject(context) {
     const options = (context.options[0] ?? {});
+    const root = options.root ?? ".";
     const ignore = options.ignore ?? [];
     if (!isSourceFile(context.filename)) {
         return undefined;
     }
-    const rootDir = resolveRootDir(options.root ?? ".", context.cwd);
-    const realRootDir = safeRealpath(rootDir);
-    const file = safeRealpath(context.filename);
-    if (realRootDir === undefined || file === undefined) {
+    const resolved = resolvedLintRoot(context.cwd, root);
+    if (resolved === undefined) {
         return undefined;
     }
+    const parse = context.sourceCode;
+    let file;
+    if (fileRealpathsByParse.has(parse)) {
+        file = fileRealpathsByParse.get(parse);
+    }
+    else {
+        file = safeRealpath(context.filename);
+        fileRealpathsByParse.set(parse, file);
+    }
+    if (file === undefined) {
+        return undefined;
+    }
+    const { rootDir, realRootDir } = resolved;
     if (!isInGraphScope(path.relative(realRootDir, file), ignore)) {
         return undefined;
     }

--- a/src/lib/findings.ts
+++ b/src/lib/findings.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
+import { derivedFromGraph } from "./derived.js";
 import { safeReaddir, safeStat } from "./fs-safe.js";
+import type { Graph } from "./graph.js";
 import {
   getSharedColocationIssue,
   isPrivateOutsideOwner,
@@ -13,6 +15,15 @@ import {
   SKIP_DIRS,
 } from "./scope.js";
 import type { Subject } from "./subject.js";
+
+export interface SingletonDirectoryStats {
+  sourceCount: number;
+  hasStylesheet: boolean;
+}
+
+const singletonStatsByGraph = derivedFromGraph(
+  () => new Map<string, SingletonDirectoryStats>(),
+);
 
 export type OwnershipFinding =
   | "singletonFolder"
@@ -51,6 +62,9 @@ function countSourceFilesRecursive(
         continue;
       }
       sourceCount += countSourceFilesRecursive(fullPath, rootDir, ignore);
+      if (sourceCount > 1) {
+        return sourceCount;
+      }
       continue;
     }
 
@@ -63,10 +77,32 @@ function countSourceFilesRecursive(
 
     if (isSourceFile(fullPath) && !isTestFile(relPath)) {
       sourceCount += 1;
+      if (sourceCount > 1) {
+        return sourceCount;
+      }
     }
   }
 
   return sourceCount;
+}
+
+export function singletonDirectoryStats(
+  dir: string,
+  rootDir: string,
+  ignore: string[],
+  graph: Graph,
+): SingletonDirectoryStats {
+  const cache = singletonStatsByGraph(graph);
+  const cached = cache.get(dir);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const sourceCount = countSourceFilesRecursive(dir, rootDir, ignore);
+  const hasStylesheet =
+    sourceCount === 1 && hasCompanionStylesheet(dir);
+  const stats: SingletonDirectoryStats = { sourceCount, hasStylesheet };
+  cache.set(dir, stats);
+  return stats;
 }
 
 function hasCompanionStylesheet(dir: string): boolean {
@@ -85,11 +121,15 @@ function isSingletonWrapperDirectory(
   filename: string,
   rootDir: string,
   ignore: string[],
+  graph: Graph,
 ): boolean {
-  if (
-    countSourceFilesRecursive(dir, rootDir, ignore) !== 1 ||
-    hasCompanionStylesheet(dir)
-  ) {
+  const { sourceCount, hasStylesheet } = singletonDirectoryStats(
+    dir,
+    rootDir,
+    ignore,
+    graph,
+  );
+  if (sourceCount !== 1 || hasStylesheet) {
     return false;
   }
 
@@ -115,7 +155,7 @@ export function ownershipFindings(
 
   if (
     dir !== rootDir &&
-    isSingletonWrapperDirectory(dir, file, rootDir, ignore)
+    isSingletonWrapperDirectory(dir, file, rootDir, ignore, graph)
   ) {
     findings.push("singletonFolder");
   }

--- a/src/lib/subject.ts
+++ b/src/lib/subject.ts
@@ -26,12 +26,7 @@ const resolvedLintRoots = new Map<
   { rootDir: string; realRootDir: string }
 >();
 
-const subjectsByParse = new WeakMap<
-  object,
-  Map<string, Subject | undefined>
->();
-
-const subjectGraphs = new WeakMap<Subject, () => void>();
+const fileRealpathsByParse = new WeakMap<object, string | undefined>();
 
 export function resolvedLintRoot(
   cwd: string,
@@ -54,60 +49,50 @@ export function resolvedLintRoot(
   return resolved;
 }
 
-function subjectOptionsKey(root: string, ignore: string[]): string {
-  return root + "\0" + ignore.join("\0");
-}
-
 export function resolveSubject(context: Rule.RuleContext): Subject | undefined {
   const options = (context.options[0] ?? {}) as SubjectOptions;
   const root = options.root ?? ".";
   const ignore = options.ignore ?? [];
-  const key = subjectOptionsKey(root, ignore);
 
-  let byOptions = subjectsByParse.get(context.sourceCode);
-  if (byOptions === undefined) {
-    byOptions = new Map();
-    subjectsByParse.set(context.sourceCode, byOptions);
-  }
-  if (byOptions.has(key)) {
-    const cached = byOptions.get(key);
-    if (cached !== undefined) {
-      subjectGraphs.get(cached)?.();
-    }
-    return cached;
+  if (!isSourceFile(context.filename)) {
+    return undefined;
   }
 
-  let subject: Subject | undefined;
-
-  if (isSourceFile(context.filename)) {
-    const resolved = resolvedLintRoot(context.cwd, root);
-    const file = safeRealpath(context.filename);
-    if (
-      resolved !== undefined &&
-      file !== undefined &&
-      isInGraphScope(path.relative(resolved.realRootDir, file), ignore)
-    ) {
-      const { rootDir, realRootDir } = resolved;
-      let graph: Graph | undefined;
-      subject = {
-        rootDir,
-        realRootDir,
-        file,
-        ignore,
-        graph: () =>
-          (graph ??= getGraph(rootDir, ignore, file, context.sourceCode)),
-        covers: (filePath) =>
-          isSourceFile(filePath) &&
-          isInGraphScope(path.relative(realRootDir, filePath), ignore),
-        display: (filePath) =>
-          path.relative(realRootDir, filePath).split(path.sep).join("/"),
-      };
-      subjectGraphs.set(subject, () => {
-        graph = undefined;
-      });
-    }
+  const resolved = resolvedLintRoot(context.cwd, root);
+  if (resolved === undefined) {
+    return undefined;
   }
 
-  byOptions.set(key, subject);
-  return subject;
+  const parse = context.sourceCode;
+  let file: string | undefined;
+  if (fileRealpathsByParse.has(parse)) {
+    file = fileRealpathsByParse.get(parse);
+  } else {
+    file = safeRealpath(context.filename);
+    fileRealpathsByParse.set(parse, file);
+  }
+
+  if (file === undefined) {
+    return undefined;
+  }
+
+  const { rootDir, realRootDir } = resolved;
+  if (!isInGraphScope(path.relative(realRootDir, file), ignore)) {
+    return undefined;
+  }
+
+  let graph: Graph | undefined;
+  return {
+    rootDir,
+    realRootDir,
+    file,
+    ignore,
+    graph: () =>
+      (graph ??= getGraph(rootDir, ignore, file, context.sourceCode)),
+    covers: (filePath) =>
+      isSourceFile(filePath) &&
+      isInGraphScope(path.relative(realRootDir, filePath), ignore),
+    display: (filePath) =>
+      path.relative(realRootDir, filePath).split(path.sep).join("/"),
+  };
 }

--- a/src/lib/subject.ts
+++ b/src/lib/subject.ts
@@ -21,36 +21,93 @@ interface SubjectOptions {
   ignore?: string[];
 }
 
+const resolvedLintRoots = new Map<
+  string,
+  { rootDir: string; realRootDir: string }
+>();
+
+const subjectsByParse = new WeakMap<
+  object,
+  Map<string, Subject | undefined>
+>();
+
+const subjectGraphs = new WeakMap<Subject, () => void>();
+
+export function resolvedLintRoot(
+  cwd: string,
+  rootOption: string,
+): { rootDir: string; realRootDir: string } | undefined {
+  const key = cwd + "\0" + rootOption;
+  const cached = resolvedLintRoots.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const rootDir = resolveRootDir(rootOption, cwd);
+  const realRootDir = safeRealpath(rootDir);
+  if (realRootDir === undefined) {
+    return undefined;
+  }
+
+  const resolved = { rootDir, realRootDir };
+  resolvedLintRoots.set(key, resolved);
+  return resolved;
+}
+
+function subjectOptionsKey(root: string, ignore: string[]): string {
+  return root + "\0" + ignore.join("\0");
+}
+
 export function resolveSubject(context: Rule.RuleContext): Subject | undefined {
   const options = (context.options[0] ?? {}) as SubjectOptions;
+  const root = options.root ?? ".";
   const ignore = options.ignore ?? [];
+  const key = subjectOptionsKey(root, ignore);
 
-  if (!isSourceFile(context.filename)) {
-    return undefined;
+  let byOptions = subjectsByParse.get(context.sourceCode);
+  if (byOptions === undefined) {
+    byOptions = new Map();
+    subjectsByParse.set(context.sourceCode, byOptions);
+  }
+  if (byOptions.has(key)) {
+    const cached = byOptions.get(key);
+    if (cached !== undefined) {
+      subjectGraphs.get(cached)?.();
+    }
+    return cached;
   }
 
-  const rootDir = resolveRootDir(options.root ?? ".", context.cwd);
-  const realRootDir = safeRealpath(rootDir);
-  const file = safeRealpath(context.filename);
-  if (realRootDir === undefined || file === undefined) {
-    return undefined;
+  let subject: Subject | undefined;
+
+  if (isSourceFile(context.filename)) {
+    const resolved = resolvedLintRoot(context.cwd, root);
+    const file = safeRealpath(context.filename);
+    if (
+      resolved !== undefined &&
+      file !== undefined &&
+      isInGraphScope(path.relative(resolved.realRootDir, file), ignore)
+    ) {
+      const { rootDir, realRootDir } = resolved;
+      let graph: Graph | undefined;
+      subject = {
+        rootDir,
+        realRootDir,
+        file,
+        ignore,
+        graph: () =>
+          (graph ??= getGraph(rootDir, ignore, file, context.sourceCode)),
+        covers: (filePath) =>
+          isSourceFile(filePath) &&
+          isInGraphScope(path.relative(realRootDir, filePath), ignore),
+        display: (filePath) =>
+          path.relative(realRootDir, filePath).split(path.sep).join("/"),
+      };
+      subjectGraphs.set(subject, () => {
+        graph = undefined;
+      });
+    }
   }
 
-  if (!isInGraphScope(path.relative(realRootDir, file), ignore)) {
-    return undefined;
-  }
-
-  let graph: Graph | undefined;
-  return {
-    rootDir,
-    realRootDir,
-    file,
-    ignore,
-    graph: () => (graph ??= getGraph(rootDir, ignore, file, context.sourceCode)),
-    covers: (filePath) =>
-      isSourceFile(filePath) &&
-      isInGraphScope(path.relative(realRootDir, filePath), ignore),
-    display: (filePath) =>
-      path.relative(realRootDir, filePath).split(path.sep).join("/"),
-  };
+  byOptions.set(key, subject);
+  return subject;
 }

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { singletonDirectoryStats } from "../src/lib/findings.js";
+import { buildGraph } from "../src/lib/graph.js";
+
+const created: string[] = [];
+
+afterEach(() => {
+  while (created.length > 0) {
+    const dir = created.pop();
+    if (dir !== undefined) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function tempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  created.push(dir);
+  return dir;
+}
+
+describe("singletonDirectoryStats", () => {
+  it("memoises per graph and directory", () => {
+    const base = fs.realpathSync(tempDir("colocate-singleton-memo-"));
+    const srcDir = path.join(base, "src");
+    const fooDir = path.join(srcDir, "Foo");
+    fs.mkdirSync(fooDir, { recursive: true });
+    fs.writeFileSync(path.join(fooDir, "a.ts"), "export const a = 1;\n");
+    fs.writeFileSync(path.join(fooDir, "b.ts"), "export const b = 1;\n");
+    fs.writeFileSync(path.join(srcDir, "app.ts"), "export const app = 1;\n");
+
+    const graph = buildGraph(srcDir, []);
+    const first = singletonDirectoryStats(fooDir, srcDir, [], graph);
+    const second = singletonDirectoryStats(fooDir, srcDir, [], graph);
+
+    expect(second).toBe(first);
+    expect(first.sourceCount).not.toBe(1);
+  });
+
+  it("does not re-walk after a sibling is added", () => {
+    const base = fs.realpathSync(tempDir("colocate-singleton-memo-"));
+    const srcDir = path.join(base, "src");
+    const fooDir = path.join(srcDir, "Foo");
+    fs.mkdirSync(fooDir, { recursive: true });
+    fs.writeFileSync(path.join(fooDir, "a.ts"), "export const a = 1;\n");
+    fs.writeFileSync(path.join(fooDir, "b.ts"), "export const b = 1;\n");
+    fs.writeFileSync(path.join(srcDir, "app.ts"), "export const app = 1;\n");
+
+    const graph = buildGraph(srcDir, []);
+    const first = singletonDirectoryStats(fooDir, srcDir, [], graph);
+    expect(first.sourceCount).not.toBe(1);
+
+    fs.writeFileSync(path.join(fooDir, "c.ts"), "export const c = 1;\n");
+    const second = singletonDirectoryStats(fooDir, srcDir, [], graph);
+
+    expect(second).toBe(first);
+  });
+
+  it("recomputes for a rebuilt graph", () => {
+    const base = fs.realpathSync(tempDir("colocate-singleton-memo-"));
+    const srcDir = path.join(base, "src");
+    const fooDir = path.join(srcDir, "Foo");
+    fs.mkdirSync(fooDir, { recursive: true });
+    fs.writeFileSync(path.join(fooDir, "a.ts"), "export const a = 1;\n");
+    fs.writeFileSync(path.join(fooDir, "b.ts"), "export const b = 1;\n");
+    fs.writeFileSync(path.join(srcDir, "app.ts"), "export const app = 1;\n");
+
+    const graph = buildGraph(srcDir, []);
+    const first = singletonDirectoryStats(fooDir, srcDir, [], graph);
+
+    fs.writeFileSync(path.join(fooDir, "c.ts"), "export const c = 1;\n");
+    const graph2 = buildGraph(srcDir, []);
+    const second = singletonDirectoryStats(fooDir, srcDir, [], graph2);
+
+    expect(second).not.toBe(first);
+  });
+
+  it("does not treat a CSS companion as a second source file, and still sees the stylesheet", () => {
+    const base = fs.realpathSync(tempDir("colocate-singleton-memo-"));
+    const srcDir = path.join(base, "src");
+    const widgetDir = path.join(srcDir, "Widget");
+    fs.mkdirSync(widgetDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(widgetDir, "Widget.ts"),
+      "export const w = 1;\n",
+    );
+    fs.writeFileSync(
+      path.join(widgetDir, "Widget.module.css"),
+      ".w {}\n",
+    );
+    fs.writeFileSync(path.join(srcDir, "app.ts"), "export const app = 1;\n");
+
+    const graph = buildGraph(srcDir, []);
+    const stats = singletonDirectoryStats(widgetDir, srcDir, [], graph);
+
+    expect(stats.sourceCount).toBe(1);
+    expect(stats.hasStylesheet).toBe(true);
+  });
+
+  it("ignored files do not count as a second source", () => {
+    const base = fs.realpathSync(tempDir("colocate-singleton-memo-"));
+    const srcDir = path.join(base, "src");
+    const fooDir = path.join(srcDir, "Foo");
+    fs.mkdirSync(fooDir, { recursive: true });
+    fs.writeFileSync(path.join(fooDir, "Foo.ts"), "export const foo = 1;\n");
+    fs.writeFileSync(path.join(fooDir, "skip.ts"), "export const skip = 1;\n");
+    fs.writeFileSync(path.join(srcDir, "app.ts"), "export const app = 1;\n");
+
+    const graph = buildGraph(srcDir, ["**/skip.ts"]);
+    const stats = singletonDirectoryStats(fooDir, srcDir, ["**/skip.ts"], graph);
+
+    expect(stats.sourceCount).toBe(1);
+    expect(stats.hasStylesheet).toBe(false);
+  });
+});

--- a/tests/subject.test.ts
+++ b/tests/subject.test.ts
@@ -1,0 +1,169 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Rule } from "eslint";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveSubject, resolvedLintRoot } from "../src/lib/subject.js";
+
+const created: string[] = [];
+
+afterEach(() => {
+  while (created.length > 0) {
+    const dir = created.pop();
+    if (dir !== undefined) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function tempDir(prefix: string): string {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+  created.push(dir);
+  return dir;
+}
+
+function context(
+  filename: string,
+  cwd: string,
+  options: { root?: string; ignore?: string[] }[],
+  sourceCode: object,
+): Rule.RuleContext {
+  return {
+    filename,
+    cwd,
+    options,
+    sourceCode,
+  } as Rule.RuleContext;
+}
+
+function writeSrcTree(base: string): void {
+  fs.mkdirSync(path.join(base, "src"), { recursive: true });
+  fs.writeFileSync(path.join(base, "src/a.ts"), "export const a = 1;\n");
+  fs.writeFileSync(path.join(base, "src/b.ts"), "export const b = 1;\n");
+}
+
+describe("resolveSubject", () => {
+  it("reuses one Subject for the same parse object and options", () => {
+    const base = tempDir("subject-reuse-");
+    writeSrcTree(base);
+    const cwd = base;
+    const filename = path.join(base, "src/a.ts");
+    const token = {};
+    const first = context(filename, cwd, [{ root: "src" }], token);
+    const second = context(filename, cwd, [{ root: "src" }], token);
+
+    const subjectA = resolveSubject(first);
+    const subjectB = resolveSubject(second);
+
+    expect(subjectA).toBeDefined();
+    expect(subjectB).toBeDefined();
+    expect(subjectB).toBe(subjectA);
+  });
+
+  it("does not reuse across parse objects", () => {
+    const base = tempDir("subject-parse-");
+    writeSrcTree(base);
+    const cwd = base;
+    const filename = path.join(base, "src/a.ts");
+    const a = context(filename, cwd, [{ root: "src" }], {});
+    const b = context(filename, cwd, [{ root: "src" }], {});
+
+    const subjectA = resolveSubject(a);
+    const subjectB = resolveSubject(b);
+
+    expect(subjectA).toBeDefined();
+    expect(subjectB).toBeDefined();
+    expect(subjectB).not.toBe(subjectA);
+    expect(subjectB!.file).toEqual(subjectA!.file);
+    expect(subjectB!.rootDir).toEqual(subjectA!.rootDir);
+    expect(subjectB!.realRootDir).toEqual(subjectA!.realRootDir);
+  });
+
+  it("does not reuse when ignore differs on the same parse", () => {
+    const base = tempDir("subject-ignore-");
+    writeSrcTree(base);
+    const cwd = base;
+    const filename = path.join(base, "src/a.ts");
+    const token = {};
+    const first = context(filename, cwd, [{ root: "src" }], token);
+    const second = context(
+      filename,
+      cwd,
+      [{ root: "src", ignore: ["**/b.ts"] }],
+      token,
+    );
+
+    const subjectA = resolveSubject(first);
+    const subjectB = resolveSubject(second);
+
+    expect(subjectA).toBeDefined();
+    expect(subjectB).toBeDefined();
+    expect(subjectB).not.toBe(subjectA);
+  });
+
+  it("does not reuse when root differs on the same parse", () => {
+    const base = tempDir("subject-root-");
+    writeSrcTree(base);
+    fs.mkdirSync(path.join(base, "other"), { recursive: true });
+    fs.writeFileSync(
+      path.join(base, "other/a.ts"),
+      "export const a = 1;\n",
+    );
+    const cwd = base;
+    const filename = path.join(base, "src/a.ts");
+    const token = {};
+    const first = context(filename, cwd, [{ root: "src" }], token);
+    const second = context(filename, cwd, [{ root: "other" }], token);
+
+    const subjectA = resolveSubject(first);
+    const subjectB = resolveSubject(second);
+
+    expect(subjectA).toBeDefined();
+    expect(subjectB).toBeUndefined();
+    expect(subjectB).not.toBe(subjectA);
+  });
+});
+
+describe("resolvedLintRoot", () => {
+  it("memoises per cwd and root option", () => {
+    const base = tempDir("root-memo-");
+    fs.mkdirSync(path.join(base, "src"), { recursive: true });
+    const expectedRootDir = path.join(base, "src");
+    const expectedRealRootDir = fs.realpathSync(expectedRootDir);
+
+    const first = resolvedLintRoot(base, "src");
+    const second = resolvedLintRoot(base, "src");
+
+    expect(second).toBe(first);
+    expect(first).toBeDefined();
+    expect(first!.rootDir).toBe(expectedRootDir);
+    expect(first!.realRootDir).toBe(expectedRealRootDir);
+  });
+
+  it("does not reuse across cwd", () => {
+    const baseA = tempDir("root-cwd-a-");
+    const baseB = tempDir("root-cwd-b-");
+    fs.mkdirSync(path.join(baseA, "src"), { recursive: true });
+    fs.mkdirSync(path.join(baseB, "src"), { recursive: true });
+
+    const rootA = resolvedLintRoot(baseA, "src");
+    const rootB = resolvedLintRoot(baseB, "src");
+
+    expect(rootA).toBeDefined();
+    expect(rootB).toBeDefined();
+    expect(rootB).not.toBe(rootA);
+  });
+
+  it("does not store a failed lookup", () => {
+    const base = tempDir("root-fail-");
+
+    expect(resolvedLintRoot(base, "src")).toBeUndefined();
+
+    fs.mkdirSync(path.join(base, "src"));
+    const result = resolvedLintRoot(base, "src");
+
+    expect(result).toBeDefined();
+    expect(result!.rootDir).toBe(path.join(base, "src"));
+    expect(result!.realRootDir).toBe(fs.realpathSync(path.join(base, "src")));
+  });
+});

--- a/tests/subject.test.ts
+++ b/tests/subject.test.ts
@@ -82,9 +82,12 @@ describe("resolveSubject", () => {
     );
     await new Promise((r) => setTimeout(r, REVALIDATE_AFTER_MS + 50));
 
-    resolveSubject(ctx);
+    const secondSubject = resolveSubject(ctx);
 
     expect(entrySubject!.graph()).toBe(g1);
+    expect(secondSubject).toBeDefined();
+    expect(secondSubject).not.toBe(entrySubject);
+    expect(secondSubject!.graph()).not.toBe(g1);
   });
 
   it("does not reuse across parse objects", () => {

--- a/tests/subject.test.ts
+++ b/tests/subject.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { Rule } from "eslint";
 import { afterEach, describe, expect, it } from "vitest";
+import { REVALIDATE_AFTER_MS } from "../src/lib/graph-cache.js";
 import { resolveSubject, resolvedLintRoot } from "../src/lib/subject.js";
 
 const created: string[] = [];
@@ -43,7 +44,7 @@ function writeSrcTree(base: string): void {
 }
 
 describe("resolveSubject", () => {
-  it("reuses one Subject for the same parse object and options", () => {
+  it("same parse and options still share file and root paths", () => {
     const base = tempDir("subject-reuse-");
     writeSrcTree(base);
     const cwd = base;
@@ -57,7 +58,33 @@ describe("resolveSubject", () => {
 
     expect(subjectA).toBeDefined();
     expect(subjectB).toBeDefined();
-    expect(subjectB).toBe(subjectA);
+    expect(subjectB).not.toBe(subjectA);
+    expect(subjectB!.file).toEqual(subjectA!.file);
+    expect(subjectB!.rootDir).toEqual(subjectA!.rootDir);
+    expect(subjectB!.realRootDir).toEqual(subjectA!.realRootDir);
+  });
+
+  it("keeps the first Subject's graph after a second resolveSubject on the same parse", async () => {
+    const base = tempDir("subject-graph-");
+    writeSrcTree(base);
+    const cwd = base;
+    const filename = path.join(base, "src/a.ts");
+    const token = {};
+    const ctx = context(filename, cwd, [{ root: "src" }], token);
+
+    const entrySubject = resolveSubject(ctx);
+    expect(entrySubject).toBeDefined();
+    const g1 = entrySubject!.graph();
+
+    fs.writeFileSync(
+      path.join(base, "src/b.ts"),
+      "export const b = 2;\n",
+    );
+    await new Promise((r) => setTimeout(r, REVALIDATE_AFTER_MS + 50));
+
+    resolveSubject(ctx);
+
+    expect(entrySubject!.graph()).toBe(g1);
   });
 
   it("does not reuse across parse objects", () => {


### PR DESCRIPTION
## Summary

- Walk each singleton-candidate directory once per graph, not once per file.
- Resolve the configured root once per working directory and `root` option.
- Keep a new Subject (and its `graph()` memo) for each `resolveSubject` call so `ownership` and `entry` cannot share one graph snapshot.

Fixes #39.

## Files

- `src/lib/findings.ts` — per-graph map of directory source count and companion CSS; still a `readdir` walk, not `graph.files`.
- `src/lib/subject.ts` — `resolvedLintRoot` cache; file `realpath` per parse; new Subject per call.
- `tests/findings.test.ts`, `tests/subject.test.ts` — identity and rebuild tests.

## Test plan

- [ ] `npm test` and `npm run typecheck`.
- [ ] Two files in one folder, same graph: `singletonDirectoryStats` returns the same object; a new graph does not.
- [ ] A folder with two source files is not a singleton. A CSS file next to one source file is not a singleton. An ignored extra file is not a second source.
- [ ] Two `resolveSubject` calls on the same parse share file and root paths but are not the same object. After an edit and `REVALIDATE_AFTER_MS`, the first Subject's `graph()` is unchanged and the second Subject's `graph()` is new.
- [ ] `resolvedLintRoot` hits for the same cwd and `root`; misses across cwd; a failed lookup is not stored.
- [ ] Existing singleton fixtures in `tests/ownership.test.ts` still report the same messages.
- [ ] Optional: `npx vite-node scripts/measure-perf.ts` — plugin extra vs parser should drop some of the ownership `readdir`/`lstat` cost. No CI timing gate.

## Remaining review findings (optional)

1. **Derive singleton counts from the graph instead of a second walk.** That would delete `countSourceFilesRecursive`. It is a rewrite, and it would break the rule that this check is a filesystem walk that never reads `graph.files` (tests, ignore, and CSS). Left unfixed.
2. **`resolvedLintRoot` keeps a successful hit for the process.** A closer `src` created later, or a retargeted root symlink, can leave `realRootDir` stale while the graph rebuilds. Failed lookups are not stored. Left unfixed: invalidation here needs a design, not a local tweak.
3. **File `realpath` cache per parse** saves one `realpath` when both rules run. A later pass could drop it if that table is not worth the extra state.

Made with [Cursor](https://cursor.com)